### PR TITLE
ParsingFailureAction and related API changes

### DIFF
--- a/Migration-5-6.md
+++ b/Migration-5-6.md
@@ -11,12 +11,14 @@ Changes in Scala API:
 1. The whole API is _finally tagless_ - all methods return `F[_]`. See [related section](README.md#scala-usage) in docs.
 1. The API now uses type-conversions - provide type and related converter when creating producer/consumer.
 See [related section](README.md#providing-converters-for-producer/consumer) in docs.
-1. The `Delivery` is now generic - e.g. `Delivery[Bytes]` (depends on type-conversion).
+1. The `Delivery` is now sealed trait - there are `Delivery.Ok[A]` (e.g. `Delivery[Bytes]` ,depends on type-conversion) and `Delivery.MalformedContent`.
+After getting the `Delivery[A]` you should pattern-match it.
 1. The API now requires an implicit `monix.execution.Scheduler` instead of `ExecutionContext`.
 1. Methods like `RabbitMQConnection.declareQueue` now return `F[Unit]` (was `Try[Done]` before).
 1. Possibility to pass manually created configurations (`ProducerConfig` etc.) is now gone. The only option is to use TypeSafe config.
 1. There is no `RabbitMQConsumer.bindTo` method anymore. Use [additional declarations](README.md#additional-declarations-and-bindings) for such thing.
 1. There are new methods in [`RabbitMQConnection`](core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala): `newChannel` and `withChannel`.
+1. [`RabbitMQPullConsumer`](README.md#pull-consumer) was added
 
 Changes in Java API:
 
@@ -27,3 +29,4 @@ Changes in Java API:
 1. Method `RabbitMQProducer.send` now returns `CompletableFuture[Void]` (was `void` before) - ***it's not blocking anymore!***
 1. `RabbitMQConsumer` and `RabbitMQProducer` (`api` module) are now traits and have their `Default*` counterparts in `core` module
 1. There is no `RabbitMQConsumer.bindTo` method anymore. Use [additional declarations](README.md#additional-declarations-and-bindings) for such thing.
+1. `RabbitMQPullConsumer` was added

--- a/Migration-5-6.md
+++ b/Migration-5-6.md
@@ -11,7 +11,7 @@ Changes in Scala API:
 1. The whole API is _finally tagless_ - all methods return `F[_]`. See [related section](README.md#scala-usage) in docs.
 1. The API now uses type-conversions - provide type and related converter when creating producer/consumer.
 See [related section](README.md#providing-converters-for-producer/consumer) in docs.
-1. The `Delivery` is now sealed trait - there are `Delivery.Ok[A]` (e.g. `Delivery[Bytes]` ,depends on type-conversion) and `Delivery.MalformedContent`.
+1. The `Delivery` is now sealed trait - there are `Delivery.Ok[A]` (e.g. `Delivery[Bytes]`, depends on type-conversion) and `Delivery.MalformedContent`.
 After getting the `Delivery[A]` you should pattern-match it.
 1. The API now requires an implicit `monix.execution.Scheduler` instead of `ExecutionContext`.
 1. Methods like `RabbitMQConnection.declareQueue` now return `F[Unit]` (was `Try[Done]` before).

--- a/api/src/main/scala/com/avast/clients/rabbitmq/api/Delivery.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/api/Delivery.scala
@@ -1,3 +1,21 @@
 package com.avast.clients.rabbitmq.api
 
-case class Delivery[+A](body: A, properties: MessageProperties, routingKey: String)
+import com.avast.bytes.Bytes
+
+sealed trait Delivery[+A] {
+  def properties: MessageProperties
+
+  def routingKey: String
+}
+
+object Delivery {
+
+  case class Ok[+A](body: A, properties: MessageProperties, routingKey: String) extends Delivery[A]
+
+  case class MalformedContent(body: Bytes, properties: MessageProperties, routingKey: String, ce: ConversionException)
+      extends Delivery[Nothing]
+
+  def apply[A](body: A, properties: MessageProperties, routingKey: String): Delivery[A] = {
+    Delivery.Ok(body, properties, routingKey)
+  }
+}

--- a/api/src/main/scala/com/avast/clients/rabbitmq/api/Delivery.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/api/Delivery.scala
@@ -1,3 +1,3 @@
 package com.avast.clients.rabbitmq.api
 
-case class Delivery[A](body: A, properties: MessageProperties, routingKey: String)
+case class Delivery[+A](body: A, properties: MessageProperties, routingKey: String)

--- a/api/src/main/scala/com/avast/clients/rabbitmq/api/Delivery.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/api/Delivery.scala
@@ -15,7 +15,7 @@ object Delivery {
   case class MalformedContent(body: Bytes, properties: MessageProperties, routingKey: String, ce: ConversionException)
       extends Delivery[Nothing]
 
-  def apply[A](body: A, properties: MessageProperties, routingKey: String): Delivery[A] = {
+  def apply[A](body: A, properties: MessageProperties, routingKey: String): Delivery.Ok[A] = {
     Delivery.Ok(body, properties, routingKey)
   }
 }

--- a/api/src/main/scala/com/avast/clients/rabbitmq/api/RabbitMQPullConsumer.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/api/RabbitMQPullConsumer.scala
@@ -1,20 +1,40 @@
 package com.avast.clients.rabbitmq.api
 
+import com.avast.bytes.Bytes
+
 import scala.language.higherKinds
 
 trait RabbitMQPullConsumer[F[_], A] {
 
   /** Retrieves one message from the queue, if there is any.
-    *
-    * @return Some(DeliveryHandle[A]) when there was a message available; None otherwise.
     */
-  def pull(): F[Option[DeliveryWithHandle[F, A]]]
+  def pull(): F[PullResult[F, A]]
 }
 
 /** Trait which contains `Delivery` and it's _handle through which it can be *acked*, *rejected* etc.
   */
-trait DeliveryWithHandle[F[_], A] {
+trait DeliveryWithHandle[+F[_], +A] {
   def delivery: Delivery[A]
 
   def handle(result: DeliveryResult): F[Unit]
+}
+
+sealed trait PullResult[+F[_], +A] {
+  def toOption: Option[DeliveryWithHandle[F, A]]
+}
+
+object PullResult {
+
+  case class Ok[F[_], A](deliveryWithHandle: DeliveryWithHandle[F, A]) extends PullResult[F, A] {
+    override def toOption: Option[DeliveryWithHandle[F, A]] = Some(deliveryWithHandle)
+  }
+
+  case object EmptyQueue extends PullResult[Nothing, Nothing] {
+    override def toOption: Option[DeliveryWithHandle[Nothing, Nothing]] = None
+  }
+
+  case class MalformedContent[F[_], A](delivery: Delivery[Bytes], ce: ConversionException) extends PullResult[F, A] {
+    override val toOption: Option[DeliveryWithHandle[F, A]] = None
+  }
+
 }

--- a/api/src/main/scala/com/avast/clients/rabbitmq/api/RabbitMQPullConsumer.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/api/RabbitMQPullConsumer.scala
@@ -1,7 +1,5 @@
 package com.avast.clients.rabbitmq.api
 
-import com.avast.bytes.Bytes
-
 import scala.language.higherKinds
 
 trait RabbitMQPullConsumer[F[_], A] {
@@ -31,10 +29,6 @@ object PullResult {
 
   case object EmptyQueue extends PullResult[Nothing, Nothing] {
     override def toOption: Option[DeliveryWithHandle[Nothing, Nothing]] = None
-  }
-
-  case class MalformedContent[F[_], A](delivery: Delivery[Bytes], ce: ConversionException) extends PullResult[F, A] {
-    override val toOption: Option[DeliveryWithHandle[F, A]] = None
   }
 
 }

--- a/api/src/main/scala/com/avast/clients/rabbitmq/api/exceptions.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/api/exceptions.scala
@@ -1,0 +1,3 @@
+package com.avast.clients.rabbitmq.api
+
+case class ConversionException(desc: String, cause: Throwable = null) extends RuntimeException(desc, cause)

--- a/api/src/main/scala/com/avast/clients/rabbitmq/javaapi/RabbitMQPullConsumer.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/javaapi/RabbitMQPullConsumer.scala
@@ -7,14 +7,40 @@ trait RabbitMQPullConsumer extends AutoCloseable {
 
   /**
     * Retrieves one message from the queue, if there is any.
-    *
-    * @return Some(DeliveryHandle[A]) when there was a message available; None otherwise.
     */
-  def pull(): CompletableFuture[Optional[DeliveryWithHandle]]
+  def pull(): CompletableFuture[PullResult]
 }
 
 trait DeliveryWithHandle {
   def delivery: Delivery
 
   def handle(result: DeliveryResult): CompletableFuture[Void]
+}
+
+sealed trait PullResult {
+  def toOptional: Optional[DeliveryWithHandle]
+
+  def isOk: Boolean
+
+  def isEmptyQueue: Boolean
+}
+
+object PullResult {
+
+  /* These two are not _case_ intentionally - it pollutes the API for Java users */
+
+  class Ok(deliveryWithHandle: DeliveryWithHandle) extends PullResult {
+    def getDeliveryWithHandle: DeliveryWithHandle = deliveryWithHandle
+
+    override val toOptional: Optional[DeliveryWithHandle] = Optional.of(deliveryWithHandle)
+    override val isOk: Boolean = true
+    override val isEmptyQueue: Boolean = false
+  }
+
+  object EmptyQueue extends PullResult {
+    override val toOptional: Optional[DeliveryWithHandle] = Optional.empty()
+    override val isOk: Boolean = false
+    override val isEmptyQueue: Boolean = true
+  }
+
 }

--- a/core/src/main/scala/com/avast/clients/rabbitmq/MultiFormatConsumer.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/MultiFormatConsumer.scala
@@ -9,44 +9,39 @@ import scala.language.higherKinds
 import scala.util.control.NonFatal
 
 class MultiFormatConsumer[F[_], A] private (supportedConverters: immutable.Seq[CheckedDeliveryConverter[A]],
-                                            action: Delivery[A] => F[DeliveryResult],
-                                            failureAction: (Delivery[Bytes], ConversionException) => F[DeliveryResult])
+                                            action: Delivery[A] => F[DeliveryResult])
     extends (Delivery[Bytes] => F[DeliveryResult])
     with StrictLogging {
   override def apply(delivery: Delivery[Bytes]): F[DeliveryResult] = {
-    val converted: Either[ConversionException, Delivery[A]] = try {
+    val converted: Delivery[A] = try {
       supportedConverters
         .collectFirst {
           case c if c.canConvert(delivery) =>
-            c.convert(delivery.body).map { newBody =>
-              delivery.copy(body = newBody)
+            delivery.flatMap[A] { d =>
+              c.convert(d.body) match {
+                case Right(a) => d.copy(body = a)
+                case Left(ce) =>
+                  logger.debug("Error while converting", ce)
+                  d.toMalformed(ce)
+              }
             }
         }
         .getOrElse {
-          Left(ConversionException(s"Could not find suitable converter for $delivery"))
+          delivery.toMalformed(ConversionException(s"Could not find suitable converter for $delivery"))
         }
     } catch {
       case NonFatal(e) =>
         logger.debug("Error while converting", e)
-        Left(ConversionException("Error while converting", e))
+        delivery.toMalformed(ConversionException("Error while converting", e))
     }
 
-    converted match {
-      case Right(convertedDelivery) => action(convertedDelivery)
-      case Left(ex: ConversionException) =>
-        logger.debug("Could not find suitable converter", ex)
-        failureAction(delivery, ex)
-      case Left(ex) =>
-        logger.debug(s"Error while converting of $delivery", ex)
-        failureAction(delivery, ex)
-    }
+    action(converted)
   }
 }
 
 object MultiFormatConsumer {
   def forType[F[_], A](supportedConverters: CheckedDeliveryConverter[A]*)(
-      action: Delivery[A] => F[DeliveryResult],
-      failureAction: (Delivery[Bytes], ConversionException) => F[DeliveryResult]): MultiFormatConsumer[F, A] = {
-    new MultiFormatConsumer[F, A](supportedConverters.toList, action, failureAction)
+      action: Delivery[A] => F[DeliveryResult]): MultiFormatConsumer[F, A] = {
+    new MultiFormatConsumer[F, A](supportedConverters.toList, action)
   }
 }

--- a/core/src/main/scala/com/avast/clients/rabbitmq/MultiFormatConsumer.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/MultiFormatConsumer.scala
@@ -1,7 +1,7 @@
 package com.avast.clients.rabbitmq
 
 import com.avast.bytes.Bytes
-import com.avast.clients.rabbitmq.api.{Delivery, DeliveryResult}
+import com.avast.clients.rabbitmq.api.{ConversionException, Delivery, DeliveryResult}
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.collection.immutable

--- a/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
@@ -35,6 +35,17 @@ trait RabbitMQConnection[F[_]] extends AutoCloseable {
   def newConsumer[A: DeliveryConverter](configName: String, monitor: Monitor)(readAction: DeliveryReadAction[F, A])(
       implicit scheduler: Scheduler): RabbitMQConsumer with AutoCloseable
 
+  /** Creates new instance of consumer, using the TypeSafe configuration passed to the factory and consumer name.
+    *
+    * @param configName           Name of configuration of the consumer.
+    * @param parsingFailureAction Action executed when the delivered message could not be parsed as A.
+    * @param monitor              Monitor for metrics.
+    * @param readAction           Action executed for each delivered message. You should never return a failed future.
+    * @param scheduler            [[Scheduler]] used for callbacks.
+    */
+  def newConsumer[A: DeliveryConverter](configName: String, parsingFailureAction: ParsingFailureAction[F], monitor: Monitor)(
+      readAction: DeliveryReadAction[F, A])(implicit scheduler: Scheduler): RabbitMQConsumer with AutoCloseable
+
   /** Creates new instance of producer, using the TypeSafe configuration passed to the factory and producer name.
     *
     * @param configName Name of configuration of the producer.
@@ -49,6 +60,16 @@ trait RabbitMQConnection[F[_]] extends AutoCloseable {
     * @param scheduler  [[Scheduler]] used for callbacks.
     */
   def newPullConsumer[A: DeliveryConverter](configName: String, monitor: Monitor)(
+      implicit scheduler: Scheduler): RabbitMQPullConsumer[F, A] with AutoCloseable
+
+  /** Creates new instance of pull consumer, using the TypeSafe configuration passed to the factory and consumer name.
+    *
+    * @param configName           Name of configuration of the consumer.
+    * @param parsingFailureAction Action executed when the delivered message could not be parsed as A.
+    * @param monitor              Monitor for metrics.
+    * @param scheduler            [[Scheduler]] used for callbacks.
+    */
+  def newPullConsumer[A: DeliveryConverter](configName: String, parsingFailureAction: ParsingFailureAction[F], monitor: Monitor)(
       implicit scheduler: Scheduler): RabbitMQPullConsumer[F, A] with AutoCloseable
 
   /**

--- a/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
@@ -35,17 +35,6 @@ trait RabbitMQConnection[F[_]] extends AutoCloseable {
   def newConsumer[A: DeliveryConverter](configName: String, monitor: Monitor)(readAction: DeliveryReadAction[F, A])(
       implicit scheduler: Scheduler): RabbitMQConsumer with AutoCloseable
 
-  /** Creates new instance of consumer, using the TypeSafe configuration passed to the factory and consumer name.
-    *
-    * @param configName           Name of configuration of the consumer.
-    * @param parsingFailureAction Action executed when the delivered message could not be parsed as A.
-    * @param monitor              Monitor for metrics.
-    * @param readAction           Action executed for each delivered message. You should never return a failed future.
-    * @param scheduler            [[Scheduler]] used for callbacks.
-    */
-  def newConsumer[A: DeliveryConverter](configName: String, parsingFailureAction: ParsingFailureAction[F], monitor: Monitor)(
-      readAction: DeliveryReadAction[F, A])(implicit scheduler: Scheduler): RabbitMQConsumer with AutoCloseable
-
   /** Creates new instance of producer, using the TypeSafe configuration passed to the factory and producer name.
     *
     * @param configName Name of configuration of the producer.
@@ -60,16 +49,6 @@ trait RabbitMQConnection[F[_]] extends AutoCloseable {
     * @param scheduler  [[Scheduler]] used for callbacks.
     */
   def newPullConsumer[A: DeliveryConverter](configName: String, monitor: Monitor)(
-      implicit scheduler: Scheduler): RabbitMQPullConsumer[F, A] with AutoCloseable
-
-  /** Creates new instance of pull consumer, using the TypeSafe configuration passed to the factory and consumer name.
-    *
-    * @param configName           Name of configuration of the consumer.
-    * @param parsingFailureAction Action executed when the delivered message could not be parsed as A.
-    * @param monitor              Monitor for metrics.
-    * @param scheduler            [[Scheduler]] used for callbacks.
-    */
-  def newPullConsumer[A: DeliveryConverter](configName: String, parsingFailureAction: ParsingFailureAction[F], monitor: Monitor)(
       implicit scheduler: Scheduler): RabbitMQPullConsumer[F, A] with AutoCloseable
 
   /**

--- a/core/src/main/scala/com/avast/clients/rabbitmq/converters.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/converters.scala
@@ -1,7 +1,7 @@
 package com.avast.clients.rabbitmq
 
 import com.avast.bytes.Bytes
-import com.avast.clients.rabbitmq.api.{Delivery, MessageProperties}
+import com.avast.clients.rabbitmq.api.{ConversionException, Delivery, MessageProperties}
 
 import scala.annotation.implicitNotFound
 
@@ -39,5 +39,3 @@ object ProductConverter {
     override def fillProperties(properties: MessageProperties): MessageProperties = properties
   }
 }
-
-case class ConversionException(desc: String, cause: Throwable = null) extends RuntimeException(desc, cause)

--- a/core/src/main/scala/com/avast/clients/rabbitmq/javaapi/DefaultRabbitMQPullConsumer.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/javaapi/DefaultRabbitMQPullConsumer.scala
@@ -18,9 +18,6 @@ class DefaultRabbitMQPullConsumer(scalaConsumer: ScalaConsumer[Future, Bytes] wi
       .map[PullResult] {
         case ScalaResult.Ok(dwh) => new PullResult.Ok(dwh.asJava)
         case ScalaResult.EmptyQueue => PullResult.EmptyQueue
-        case ScalaResult.MalformedContent(d, ce) =>
-          logger.warn(s"Detected error while conversion although it should NOT happen: $d", ce)
-          throw ce
       }
       .asJava
   }

--- a/core/src/main/scala/com/avast/clients/rabbitmq/javaapi/DefaultRabbitMQPullConsumer.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/javaapi/DefaultRabbitMQPullConsumer.scala
@@ -1,20 +1,27 @@
 package com.avast.clients.rabbitmq.javaapi
 
-import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
 import com.avast.bytes.Bytes
-import com.avast.clients.rabbitmq.api.{RabbitMQPullConsumer => ScalaConsumer}
+import com.avast.clients.rabbitmq.api.{PullResult => ScalaResult, RabbitMQPullConsumer => ScalaConsumer}
 import com.avast.clients.rabbitmq.javaapi.JavaConverters._
+import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class DefaultRabbitMQPullConsumer(scalaConsumer: ScalaConsumer[Future, Bytes] with AutoCloseable)(implicit ec: ExecutionContext)
-    extends RabbitMQPullConsumer {
-  override def pull(): CompletableFuture[Optional[DeliveryWithHandle]] = {
+    extends RabbitMQPullConsumer
+    with StrictLogging {
+  override def pull(): CompletableFuture[PullResult] = {
     scalaConsumer
       .pull()
-      .map(_.map(_.asJava).asJava)
+      .map[PullResult] {
+        case ScalaResult.Ok(dwh) => new PullResult.Ok(dwh.asJava)
+        case ScalaResult.EmptyQueue => PullResult.EmptyQueue
+        case ScalaResult.MalformedContent(d, ce) =>
+          logger.warn(s"Detected error while conversion although it should NOT happen: $d", ce)
+          throw ce
+      }
       .asJava
   }
 

--- a/core/src/main/scala/com/avast/clients/rabbitmq/javaapi/JavaConverters.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/javaapi/JavaConverters.scala
@@ -152,14 +152,15 @@ private[rabbitmq] object JavaConverters {
   }
 
   implicit class ScalaDeliveryConversion(val d: ScalaDelivery[Bytes]) extends AnyVal {
-    def asJava: JavaDelivery = {
-      new JavaDelivery(d.routingKey, d.body, d.properties.asJava)
+    def asJava: JavaDelivery = d match {
+      case ScalaDelivery.Ok(body, properties, routingKey) => new JavaDelivery(routingKey, body, properties.asJava)
+      case ScalaDelivery.MalformedContent(_, _, _, ce) => throw ce
     }
   }
 
   implicit class JavaDeliveryConversion(val d: JavaDelivery) extends AnyVal {
     def asScala: ScalaDelivery[Bytes] = {
-      ScalaDelivery(d.getBody, d.getProperties.asScala, d.getRoutingKey)
+      ScalaDelivery.Ok(d.getBody, d.getProperties.asScala, d.getRoutingKey)
     }
   }
 

--- a/core/src/main/scala/com/avast/clients/rabbitmq/javaapi/JavaConverters.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/javaapi/JavaConverters.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.{CompletableFuture, Executor}
 import java.util.{function, Date, Optional}
 
 import com.avast.bytes.Bytes
+import com.avast.clients.rabbitmq.DeliveryReadAction
 import com.avast.clients.rabbitmq.api.{
   Delivery => ScalaDelivery,
   DeliveryResult => ScalaResult,
@@ -191,7 +192,7 @@ private[rabbitmq] object JavaConverters {
   }
 
   implicit class JavaActionConversion(val readAction: function.Function[JavaDelivery, CompletableFuture[DeliveryResult]]) extends AnyVal {
-    def asScala(implicit ex: Executor, ec: ExecutionContext): ScalaDelivery[Bytes] => Future[ScalaResult] =
+    def asScala(implicit ex: Executor, ec: ExecutionContext): DeliveryReadAction[Future, Bytes] =
       d => readAction(d.asJava).asScala.map(_.asScala)
   }
 

--- a/core/src/main/scala/com/avast/clients/rabbitmq/rabbitmq.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/rabbitmq.scala
@@ -2,7 +2,8 @@ package com.avast.clients
 
 import cats.arrow.FunctionK
 import cats.{~>, Monad}
-import com.avast.clients.rabbitmq.api.{Delivery, DeliveryResult, MessageProperties, RabbitMQProducer}
+import com.avast.bytes.Bytes
+import com.avast.clients.rabbitmq.api._
 import com.rabbitmq.client.{RecoverableChannel, RecoverableConnection}
 import mainecoon.FunctorK
 import monix.eval.Task
@@ -17,7 +18,8 @@ package object rabbitmq {
   private[rabbitmq] type ServerConnection = RecoverableConnection
   private[rabbitmq] type ServerChannel = RecoverableChannel
 
-  type DeliveryReadAction[F[_], A] = Delivery[A] => F[DeliveryResult]
+  type DeliveryReadAction[F[_], -A] = Delivery[A] => F[DeliveryResult]
+  type ParsingFailureAction[F[_]] = (String, Delivery[Bytes], ConversionException) => F[DeliveryResult]
 
   type FromTask[A[_]] = FunctionK[Task, A]
   type ToTask[A[_]] = FunctionK[A, Task]

--- a/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQPullConsumerTest.scala
+++ b/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQPullConsumerTest.scala
@@ -3,7 +3,7 @@ package com.avast.clients.rabbitmq
 import java.util.UUID
 
 import com.avast.bytes.Bytes
-import com.avast.clients.rabbitmq.api.DeliveryResult
+import com.avast.clients.rabbitmq.api.{ConversionException, DeliveryResult, PullResult}
 import com.avast.metrics.scalaapi.Monitor
 import com.rabbitmq.client.AMQP.BasicProperties
 import com.rabbitmq.client.impl.recovery.AutorecoveringChannel
@@ -47,11 +47,12 @@ class DefaultRabbitMQPullConsumerTest extends FunSuite with MockitoSugar with Sc
       channel,
       "queueName",
       DeliveryResult.Reject,
+      (_, _, _) => fail(),
       Monitor.noOp,
       Scheduler.global
     )
 
-    val Some(dwh) = consumer.pull().futureValue
+    val PullResult.Ok(dwh) = consumer.pull().futureValue
 
     assertResult(Some(messageId))(dwh.delivery.properties.messageId)
 
@@ -89,11 +90,12 @@ class DefaultRabbitMQPullConsumerTest extends FunSuite with MockitoSugar with Sc
       channel,
       "queueName",
       DeliveryResult.Reject,
+      (_, _, _) => fail(),
       Monitor.noOp,
       Scheduler.global
     )
 
-    val Some(dwh) = consumer.pull().futureValue
+    val PullResult.Ok(dwh) = consumer.pull().futureValue
 
     assertResult(Some(messageId))(dwh.delivery.properties.messageId)
 
@@ -131,11 +133,12 @@ class DefaultRabbitMQPullConsumerTest extends FunSuite with MockitoSugar with Sc
       channel,
       "queueName",
       DeliveryResult.Ack,
+      (_, _, _) => fail(),
       Monitor.noOp,
       Scheduler.global
     )
 
-    val Some(dwh) = consumer.pull().futureValue
+    val PullResult.Ok(dwh) = consumer.pull().futureValue
 
     assertResult(Some(messageId))(dwh.delivery.properties.messageId)
 
@@ -172,11 +175,12 @@ class DefaultRabbitMQPullConsumerTest extends FunSuite with MockitoSugar with Sc
       channel,
       "queueName",
       DeliveryResult.Reject,
+      (_, _, _) => fail(),
       Monitor.noOp,
       Scheduler.global
     )
 
-    val Some(dwh) = consumer.pull().futureValue
+    val PullResult.Ok(dwh) = consumer.pull().futureValue
 
     assertResult(Some(messageId))(dwh.delivery.properties.messageId)
 
@@ -220,6 +224,7 @@ class DefaultRabbitMQPullConsumerTest extends FunSuite with MockitoSugar with Sc
       channel,
       "queueName",
       DeliveryResult.Retry,
+      (_, _, _) => fail(),
       Monitor.noOp,
       Scheduler.global
     )
@@ -265,7 +270,8 @@ class DefaultRabbitMQPullConsumerTest extends FunSuite with MockitoSugar with Sc
       "test",
       channel,
       "queueName",
-      DeliveryResult.Retry,
+      DeliveryResult.Ack,
+      (_, _, _) => Future.successful(DeliveryResult.Retry),
       Monitor.noOp,
       Scheduler.global
     )

--- a/core/src/test/scala/com/avast/clients/rabbitmq/MultiFormatConsumerTest.scala
+++ b/core/src/test/scala/com/avast/clients/rabbitmq/MultiFormatConsumerTest.scala
@@ -3,7 +3,7 @@ package com.avast.clients.rabbitmq
 import com.avast.bytes.Bytes
 import com.avast.bytes.gpb.ByteStringBytes
 import com.avast.cactus.bytes._
-import com.avast.clients.rabbitmq.api.{Delivery, DeliveryResult, MessageProperties}
+import com.avast.clients.rabbitmq.api.{ConversionException, Delivery, DeliveryResult, MessageProperties}
 import com.avast.clients.rabbitmq.extras.format._
 import com.avast.clients.rabbitmq.test.ExampleEvents.{FileSource => FileSourceGpb, NewFileSourceAdded => NewFileSourceAddedGpb}
 import com.google.protobuf.ByteString

--- a/core/src/test/scala/com/avast/clients/rabbitmq/MultiFormatConsumerTest.scala
+++ b/core/src/test/scala/com/avast/clients/rabbitmq/MultiFormatConsumerTest.scala
@@ -32,13 +32,13 @@ class MultiFormatConsumerTest extends FunSuite with ScalaFutures {
   case class NewFileSourceAdded(fileSources: Seq[FileSource])
 
   test("basic") {
-    val consumer = MultiFormatConsumer.forType[Future, String](StringDeliveryConverter)(
-      d => {
+    val consumer = MultiFormatConsumer.forType[Future, String](StringDeliveryConverter) {
+      case d: Delivery.Ok[String] =>
         assertResult("abc321")(d.body)
         Future.successful(DeliveryResult.Ack)
-      },
-      (_, _) => Future.successful(DeliveryResult.Reject)
-    )
+
+      case _ => fail()
+    }
 
     val delivery = Delivery(
       body = Bytes.copyFromUtf8("abc321"),
@@ -52,10 +52,12 @@ class MultiFormatConsumerTest extends FunSuite with ScalaFutures {
   }
 
   test("non-supported content-type") {
-    val consumer = MultiFormatConsumer.forType[Future, String](StringDeliveryConverter)(
-      _ => Future.successful(DeliveryResult.Ack),
-      (_, _) => Future.successful(DeliveryResult.Reject)
-    )
+    val consumer = MultiFormatConsumer.forType[Future, String](StringDeliveryConverter) {
+      case _: Delivery.Ok[NewFileSourceAdded] =>
+        Future.successful(DeliveryResult.Ack)
+      case _ =>
+        Future.successful(DeliveryResult.Reject)
+    }
 
     val delivery = Delivery(
       body = Bytes.copyFromUtf8("abc321"),
@@ -69,8 +71,8 @@ class MultiFormatConsumerTest extends FunSuite with ScalaFutures {
   }
 
   test("json") {
-    val consumer = MultiFormatConsumer.forType[Future, NewFileSourceAdded](JsonDeliveryConverter.derive())(
-      d => {
+    val consumer = MultiFormatConsumer.forType[Future, NewFileSourceAdded](JsonDeliveryConverter.derive()) {
+      case d: Delivery.Ok[NewFileSourceAdded] =>
         assertResult(
           NewFileSourceAdded(
             Seq(
@@ -79,9 +81,9 @@ class MultiFormatConsumerTest extends FunSuite with ScalaFutures {
             )))(d.body)
 
         Future.successful(DeliveryResult.Ack)
-      },
-      (_, _) => Future.successful(DeliveryResult.Reject)
-    )
+
+      case _ => Future.successful(DeliveryResult.Reject)
+    }
 
     val delivery = Delivery(
       body = Bytes.copyFromUtf8(s"""
@@ -100,11 +102,9 @@ class MultiFormatConsumerTest extends FunSuite with ScalaFutures {
   }
 
   test("gpb") {
-    val consumer = MultiFormatConsumer.forType[Future, NewFileSourceAdded](
-      JsonDeliveryConverter.derive(),
-      GpbDeliveryConverter[NewFileSourceAddedGpb].derive()
-    )(
-      d => {
+    val consumer = MultiFormatConsumer.forType[Future, NewFileSourceAdded](JsonDeliveryConverter.derive(),
+                                                                           GpbDeliveryConverter[NewFileSourceAddedGpb].derive()) {
+      case d: Delivery.Ok[NewFileSourceAdded] =>
         assertResult(
           NewFileSourceAdded(
             Seq(
@@ -113,9 +113,9 @@ class MultiFormatConsumerTest extends FunSuite with ScalaFutures {
             )))(d.body)
 
         Future.successful(DeliveryResult.Ack)
-      },
-      (_, _) => Future.successful(DeliveryResult.Reject)
-    )
+
+      case _ => fail()
+    }
 
     val delivery = Delivery(
       body = ByteStringBytes.wrap {

--- a/extras-cactus/src/main/scala/com/avast/clients/rabbitmq/extras/format/GpbDeliveryConverter.scala
+++ b/extras-cactus/src/main/scala/com/avast/clients/rabbitmq/extras/format/GpbDeliveryConverter.scala
@@ -4,8 +4,8 @@ import cats.syntax.either._
 import com.avast.bytes.Bytes
 import com.avast.cactus.CactusParser._
 import com.avast.cactus.Converter
-import com.avast.clients.rabbitmq.api.Delivery
-import com.avast.clients.rabbitmq.{CheckedDeliveryConverter, ConversionException}
+import com.avast.clients.rabbitmq.CheckedDeliveryConverter
+import com.avast.clients.rabbitmq.api.{ConversionException, Delivery}
 import com.google.protobuf.MessageLite
 
 import scala.annotation.implicitNotFound

--- a/extras-cactus/src/main/scala/com/avast/clients/rabbitmq/extras/format/GpbProductConverter.scala
+++ b/extras-cactus/src/main/scala/com/avast/clients/rabbitmq/extras/format/GpbProductConverter.scala
@@ -5,8 +5,8 @@ import com.avast.bytes.Bytes
 import com.avast.bytes.gpb.ByteStringBytes
 import com.avast.cactus.CactusParser._
 import com.avast.cactus.Converter
-import com.avast.clients.rabbitmq.api.MessageProperties
-import com.avast.clients.rabbitmq.{ConversionException, ProductConverter}
+import com.avast.clients.rabbitmq.ProductConverter
+import com.avast.clients.rabbitmq.api.{ConversionException, MessageProperties}
 import com.google.protobuf.MessageLite
 
 import scala.annotation.implicitNotFound

--- a/extras-circe/src/main/scala/com/avast/clients/rabbitmq/extras/format/JsonDeliveryConverter.scala
+++ b/extras-circe/src/main/scala/com/avast/clients/rabbitmq/extras/format/JsonDeliveryConverter.scala
@@ -2,8 +2,8 @@ package com.avast.clients.rabbitmq.extras.format
 
 import cats.syntax.either._
 import com.avast.bytes.Bytes
-import com.avast.clients.rabbitmq.api.Delivery
-import com.avast.clients.rabbitmq.{CheckedDeliveryConverter, ConversionException}
+import com.avast.clients.rabbitmq.CheckedDeliveryConverter
+import com.avast.clients.rabbitmq.api.{ConversionException, Delivery}
 import io.circe.Decoder
 import io.circe.parser.decode
 

--- a/extras-circe/src/main/scala/com/avast/clients/rabbitmq/extras/format/JsonProductConverter.scala
+++ b/extras-circe/src/main/scala/com/avast/clients/rabbitmq/extras/format/JsonProductConverter.scala
@@ -1,8 +1,8 @@
 package com.avast.clients.rabbitmq.extras.format
 
 import com.avast.bytes.Bytes
-import com.avast.clients.rabbitmq.api.MessageProperties
-import com.avast.clients.rabbitmq.{ConversionException, ProductConverter}
+import com.avast.clients.rabbitmq.ProductConverter
+import com.avast.clients.rabbitmq.api.{ConversionException, MessageProperties}
 import io.circe.Encoder
 import io.circe.syntax._
 

--- a/scalastyle_config.xml
+++ b/scalastyle_config.xml
@@ -128,7 +128,7 @@ it tries to lay a common ground using the official style guide: http://docs.scal
     </check>
     <check class="org.scalastyle.scalariform.ParameterNumberChecker" level="warning" enabled="true">
         <parameters>
-            <parameter name="maxParameters">8</parameter>
+            <parameter name="maxParameters">10</parameter>
         </parameters>
     </check>
     <check class="org.scalastyle.scalariform.PatternMatchAlignChecker" level="warning" enabled="false"/>


### PR DESCRIPTION
PullResult instead of Option for RabbitMQPullConsumer
ConversionException to api module

Sorry for so big PR however it's cause mainly by moving `ConversionException` into another package (and module).