### PR TITLE
Better config errors - contain understandable config path

### DIFF
--- a/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConnection.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConnection.scala
@@ -2,6 +2,7 @@ package com.avast.clients.rabbitmq
 
 import cats.effect.Effect
 import cats.syntax.all._
+import com.avast.clients.rabbitmq.DefaultRabbitMQClientFactory.FakeConfigRootName
 import com.avast.clients.rabbitmq.api.{FAutoCloseable, RabbitMQConsumer, RabbitMQProducer, RabbitMQPullConsumer}
 import com.avast.metrics.scalaapi.Monitor
 import com.rabbitmq.client.ShutdownSignalException
@@ -61,7 +62,14 @@ class DefaultRabbitMQConnection[F[_]](connection: ServerConnection,
         implicit val scheduler = Scheduler(ses, ec)
 
         DefaultRabbitMQClientFactory.Consumer
-          .fromConfig[F, A](config.getConfig(configName), channel, info, blockingScheduler, monitor, consumerListener, readAction)
+          .fromConfig[F, A](config.getConfig(configName),
+                            s"$FakeConfigRootName.$configName",
+                            channel,
+                            info,
+                            blockingScheduler,
+                            monitor,
+                            consumerListener,
+                            readAction)
       }
     }
   }
@@ -73,7 +81,7 @@ class DefaultRabbitMQConnection[F[_]](connection: ServerConnection,
         implicit val scheduler = Scheduler(ses, ec)
 
         DefaultRabbitMQClientFactory.Consumer
-          .create[F, A](consumerConfig, channel, info, blockingScheduler, monitor, consumerListener, readAction)
+          .create[F, A](consumerConfig, "_manually_provided_", channel, info, blockingScheduler, monitor, consumerListener, readAction)
       }
     }
   }
@@ -85,7 +93,7 @@ class DefaultRabbitMQConnection[F[_]](connection: ServerConnection,
         implicit val scheduler = Scheduler(ses, ec)
 
         DefaultRabbitMQClientFactory.PullConsumer
-          .fromConfig[F, A](config.getConfig(configName), channel, info, blockingScheduler, monitor)
+          .fromConfig[F, A](config.getConfig(configName), s"$FakeConfigRootName.$configName", channel, info, blockingScheduler, monitor)
       }
     }
   }
@@ -97,7 +105,7 @@ class DefaultRabbitMQConnection[F[_]](connection: ServerConnection,
         implicit val scheduler = Scheduler(ses, ec)
 
         DefaultRabbitMQClientFactory.PullConsumer
-          .create[F, A](pullConsumerConfig, channel, info, blockingScheduler, monitor)
+          .create[F, A](pullConsumerConfig, "_manually_provided_", channel, info, blockingScheduler, monitor)
       }
     }
   }
@@ -108,7 +116,7 @@ class DefaultRabbitMQConnection[F[_]](connection: ServerConnection,
         implicit val scheduler = Scheduler(ses, ec)
 
         DefaultRabbitMQClientFactory.Producer
-          .fromConfig[F, A](config.getConfig(configName), channel, info, blockingScheduler, monitor)
+          .fromConfig[F, A](config.getConfig(configName), s"$FakeConfigRootName.$configName", channel, info, blockingScheduler, monitor)
       }
     }
   }
@@ -120,7 +128,7 @@ class DefaultRabbitMQConnection[F[_]](connection: ServerConnection,
         implicit val scheduler = Scheduler(ses, ec)
 
         DefaultRabbitMQClientFactory.Producer
-          .create[F, A](producerConfig, channel, info, blockingScheduler, monitor)
+          .create[F, A](producerConfig, "_manually_provided_", channel, info, blockingScheduler, monitor)
       }
     }
   }

--- a/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
@@ -5,6 +5,7 @@ import java.time.Duration
 import java.util.concurrent.ExecutorService
 
 import cats.effect.{Effect, Sync}
+import com.avast.clients.rabbitmq.DefaultRabbitMQClientFactory.FakeConfigRootName
 import com.avast.clients.rabbitmq.api._
 import com.avast.clients.rabbitmq.ssl.{KeyStoreTypes, SSLBuilder}
 import com.avast.metrics.scalaapi.Monitor
@@ -141,9 +142,9 @@ object RabbitMQConnection extends StrictLogging {
     // we need to wrap it with one level, to be able to parse it with Ficus
     val config = ConfigFactory
       .empty()
-      .withValue("root", providedConfig.withFallback(DefaultConfig).root())
+      .withValue(FakeConfigRootName, providedConfig.withFallback(DefaultConfig).root())
 
-    val connectionConfig = config.as[RabbitMQConnectionConfig]("root")
+    val connectionConfig = config.as[RabbitMQConnectionConfig](FakeConfigRootName)
 
     val connection = createConnection(connectionConfig, blockingExecutor, connectionListener, channelListener, consumerListener)
 


### PR DESCRIPTION
Examples:

Missing value in producer/consumer/pull consumer config:
```
No configuration setting found for key '_rabbitmq_config_root_.producer.name'
```
Missing value in consumer/pull consumer bindings
```
No configuration setting found for key '_rabbitmq_config_root_.pullConsumer.bindings.0.exchange.declare.type'
```

The `_rabbitmq_config_root_` is just a placeholder (it can be changed if you want) because the library has no clue about absolute path in your applications's configuration.