### PR TITLE
Better recovery logging

### DIFF
--- a/api/src/main/scala/com/avast/clients/rabbitmq/api/exceptions.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/api/exceptions.scala
@@ -1,3 +1,6 @@
 package com.avast.clients.rabbitmq.api
+import java.io.IOException
 
 case class ConversionException(desc: String, cause: Throwable = null) extends RuntimeException(desc, cause)
+
+case class ChannelNotRecoveredException(desc: String, cause: Throwable = null) extends IOException(desc, cause)

--- a/core/src/main/scala/com/avast/clients/rabbitmq/ChannelListener.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/ChannelListener.scala
@@ -41,9 +41,9 @@ object ChannelListener {
 
     override def onShutdown(cause: ShutdownSignalException, channel: Channel): Unit = {
       if (cause.isInitiatedByApplication) {
-        logger.info(s"Channel shutdown: $channel")
+        logger.debug(s"Channel shutdown: $channel")
       } else {
-        logger.warn(s"Channel shutdown: $channel", cause)
+        logger.info(s"Channel shutdown: $channel", cause)
       }
     }
   }

--- a/core/src/main/scala/com/avast/clients/rabbitmq/ConnectionListener.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/ConnectionListener.scala
@@ -41,9 +41,9 @@ object ConnectionListener {
 
     override def onShutdown(connection: Connection, cause: ShutdownSignalException): Unit = {
       if (cause.isInitiatedByApplication) {
-        logger.info(s"Connection shutdown: $connection (name ${connection.getClientProvidedName})")
+        logger.debug(s"Connection shutdown: $connection (name ${connection.getClientProvidedName})")
       } else {
-        logger.warn(s"Connection shutdown: $connection (name ${connection.getClientProvidedName})", cause)
+        logger.info(s"Connection shutdown: $connection (name ${connection.getClientProvidedName})", cause)
       }
     }
   }

--- a/core/src/main/scala/com/avast/clients/rabbitmq/ConsumerListener.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/ConsumerListener.scala
@@ -22,9 +22,9 @@ object ConsumerListener {
                             consumerTag: String,
                             cause: ShutdownSignalException): Unit = {
       if (cause.isInitiatedByApplication) {
-        logger.info(s"[$consumerName] Shutdown of consumer on channel $channel")
+        logger.debug(s"[$consumerName] Shutdown of consumer on channel $channel")
       } else {
-        logger.warn(s"[$consumerName] Shutdown of consumer on channel $channel", cause)
+        logger.info(s"[$consumerName] Shutdown of consumer on channel $channel", cause)
       }
     }
   }

--- a/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
@@ -1,5 +1,6 @@
 package com.avast.clients.rabbitmq
 
+import java.io.IOException
 import java.nio.file.{Path, Paths}
 import java.time.Duration
 import java.util.concurrent.ExecutorService
@@ -247,16 +248,19 @@ object RabbitMQConnection extends StrictLogging {
                                      consumerListener: ConsumerListener): ExceptionHandler with RecoveryListener =
     new ExceptionHandler with RecoveryListener {
       override def handleReturnListenerException(channel: Channel, exception: Throwable): Unit = {
-        logger.info(s"Return listener error on channel $channel", exception)
+        logger.info(
+          s"Return listener error on channel $channel (on connection ${channel.getConnection}, name ${channel.getConnection.getClientProvidedName})",
+          exception
+        )
       }
 
       override def handleConnectionRecoveryException(conn: Connection, exception: Throwable): Unit = {
-        logger.debug(s"Recovery error on connection $conn", exception)
+        logger.debug(s"Recovery error on connection $conn (name ${conn.getClientProvidedName})", exception)
         connectionListener.onRecoveryFailure(conn, exception)
       }
 
-      override def handleBlockedListenerException(connection: Connection, exception: Throwable): Unit = {
-        logger.info(s"Recovery error on connection $connection", exception)
+      override def handleBlockedListenerException(conn: Connection, exception: Throwable): Unit = {
+        logger.info(s"Recovery error on connection $conn (name ${conn.getClientProvidedName})", exception)
       }
 
       override def handleChannelRecoveryException(ch: Channel, exception: Throwable): Unit = {
@@ -265,7 +269,10 @@ object RabbitMQConnection extends StrictLogging {
       }
 
       override def handleUnexpectedConnectionDriverException(conn: Connection, exception: Throwable): Unit = {
-        logger.info("RabbitMQ driver exception", exception)
+        exception match {
+          case ioe: IOException => logger.info(s"RabbitMQ IO exception on $conn (name ${conn.getClientProvidedName})", ioe)
+          case e => logger.debug(s"RabbitMQ unexpected exception on $conn (name ${conn.getClientProvidedName})", e)
+        }
       }
 
       override def handleConsumerException(channel: Channel,
@@ -284,7 +291,7 @@ object RabbitMQConnection extends StrictLogging {
       }
 
       override def handleTopologyRecoveryException(conn: Connection, ch: Channel, exception: TopologyRecoveryException): Unit = {
-        logger.debug(s"Topology recovery error on channel $ch (connection $conn)", exception)
+        logger.debug(s"Topology recovery error on channel $ch (on connection $conn, name ${conn.getClientProvidedName})", exception)
         channelListener.onRecoveryFailure(ch, exception)
       }
 


### PR DESCRIPTION
Lowered logging level for most occasions to prevent log congestion by RabbitMQ client. Added more info to some log messages.  
Under normal circumstances, it should output nothing on WARN level now (n.c. means successful recovery of node failure/shutdown.  
Sending failure (caused by sending through non-recovered channel is now indicated with `ChannelNotRecoveredException` (and it's user's responsibility to retry the operation).