### PR TITLE
Republishing aware of UserID

### DIFF
--- a/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQClientFactory.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQClientFactory.scala
@@ -313,13 +313,13 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
   }
 
   private[rabbitmq] def declareExchange(name: String,
-                                        channelFactoryInfo: RabbitMQConnectionInfo,
+                                        connectionInfo: RabbitMQConnectionInfo,
                                         channel: ServerChannel,
                                         autoDeclareExchange: AutoDeclareExchange): Unit = {
     import autoDeclareExchange._
 
     if (enabled) {
-      declareExchange(name, `type`, durable, autoDelete, arguments, channel, channelFactoryInfo)
+      declareExchange(name, `type`, durable, autoDelete, arguments, channel, connectionInfo)
     }
     ()
   }
@@ -330,8 +330,8 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
                               autoDelete: Boolean,
                               arguments: DeclareArguments,
                               channel: ServerChannel,
-                              channelFactoryInfo: RabbitMQConnectionInfo): Unit = {
-    logger.info(s"Declaring exchange '$name' of type ${`type`} in virtual host '${channelFactoryInfo.virtualHost}'")
+                              connectionInfo: RabbitMQConnectionInfo): Unit = {
+    logger.info(s"Declaring exchange '$name' of type ${`type`} in virtual host '${connectionInfo.virtualHost}'")
     val javaArguments = argsAsJava(arguments.value)
     channel.exchangeDeclare(name, `type`, durable, autoDelete, javaArguments)
     ()
@@ -365,7 +365,7 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
   private def preparePullConsumer[F[_]: Effect, A: DeliveryConverter](
       consumerConfig: PullConsumerConfig,
       configName: String,
-      channelFactoryInfo: RabbitMQConnectionInfo,
+      connectionInfo: RabbitMQConnectionInfo,
       channel: ServerChannel,
       blockingScheduler: Scheduler,
       monitor: Monitor)(implicit scheduler: Scheduler): DefaultRabbitMQPullConsumer[F, A] = {
@@ -373,25 +373,25 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
     import consumerConfig._
 
     // auto declare exchanges
-    declareExchangesFromBindings(configName, channelFactoryInfo, channel, consumerConfig.bindings)
+    declareExchangesFromBindings(configName, connectionInfo, channel, consumerConfig.bindings)
 
     // auto declare queue
-    declareQueue(queueName, channelFactoryInfo, channel, declare)
+    declareQueue(queueName, connectionInfo, channel, declare)
 
     // auto bind
-    bindQueues(channelFactoryInfo, channel, consumerConfig.queueName, consumerConfig.bindings)
+    bindQueues(connectionInfo, channel, consumerConfig.queueName, consumerConfig.bindings)
 
-    new DefaultRabbitMQPullConsumer[F, A](name, channel, queueName, failureAction, monitor, blockingScheduler)
+    new DefaultRabbitMQPullConsumer[F, A](name, channel, queueName, connectionInfo, failureAction, monitor, blockingScheduler)
   }
 
   private def declareQueue(queueName: String,
-                           channelFactoryInfo: RabbitMQConnectionInfo,
+                           connectionInfo: RabbitMQConnectionInfo,
                            channel: ServerChannel,
                            declare: AutoDeclareQueue): Unit = {
     import declare._
 
     if (enabled) {
-      logger.info(s"Declaring queue '$queueName' in virtual host '${channelFactoryInfo.virtualHost}'")
+      logger.info(s"Declaring queue '$queueName' in virtual host '${connectionInfo.virtualHost}'")
       declareQueue(channel, queueName, durable, exclusive, autoDelete, arguments)
     }
   }
@@ -405,7 +405,7 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
     channel.queueDeclare(queueName, durable, exclusive, autoDelete, arguments.value)
   }
 
-  private def bindQueues(channelFactoryInfo: RabbitMQConnectionInfo,
+  private def bindQueues(connectionInfo: RabbitMQConnectionInfo,
                          channel: ServerChannel,
                          queueName: String,
                          bindings: immutable.Seq[AutoBindQueue]): Unit = {
@@ -413,7 +413,7 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
       import bind._
       val exchangeName = bind.exchange.name
 
-      bindQueues(channel, queueName, exchangeName, routingKeys, bindArguments, channelFactoryInfo)
+      bindQueues(channel, queueName, exchangeName, routingKeys, bindArguments, connectionInfo)
     }
   }
 
@@ -422,22 +422,22 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
                          exchangeName: String,
                          routingKeys: immutable.Seq[String],
                          bindArguments: BindArguments,
-                         channelFactoryInfo: RabbitMQConnectionInfo): Unit = {
+                         connectionInfo: RabbitMQConnectionInfo): Unit = {
     if (routingKeys.nonEmpty) {
       routingKeys.foreach { routingKey =>
-        bindQueue(channelFactoryInfo)(channel, queueName)(exchangeName, routingKey, bindArguments.value)
+        bindQueue(connectionInfo)(channel, queueName)(exchangeName, routingKey, bindArguments.value)
       }
     } else {
       // binding without routing key, possibly to fanout exchange
 
-      bindQueue(channelFactoryInfo)(channel, queueName)(exchangeName, "", bindArguments.value)
+      bindQueue(connectionInfo)(channel, queueName)(exchangeName, "", bindArguments.value)
     }
   }
 
-  private[rabbitmq] def bindQueue(channelFactoryInfo: RabbitMQConnectionInfo)(
+  private[rabbitmq] def bindQueue(connectionInfo: RabbitMQConnectionInfo)(
       channel: ServerChannel,
       queueName: String)(exchangeName: String, routingKey: String, arguments: ArgumentsMap): AMQP.Queue.BindOk = {
-    logger.info(s"Binding exchange $exchangeName($routingKey) -> queue '$queueName' in virtual host '${channelFactoryInfo.virtualHost}'")
+    logger.info(s"Binding exchange $exchangeName($routingKey) -> queue '$queueName' in virtual host '${connectionInfo.virtualHost}'")
 
     channel.queueBind(queueName, exchangeName, routingKey, arguments)
   }
@@ -455,7 +455,7 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
   }
 
   private def declareExchangesFromBindings(configName: String,
-                                           channelFactoryInfo: RabbitMQConnectionInfo,
+                                           connectionInfo: RabbitMQConnectionInfo,
                                            channel: ServerChannel,
                                            bindings: Seq[AutoBindQueue]): Unit = {
     bindings.zipWithIndex.foreach {
@@ -467,13 +467,13 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
           val path = s"$configName.bindings.$i.exchange.declare"
           val d = declare.wrapped(path).as[AutoDeclareExchange](path)
 
-          declareExchange(name, channelFactoryInfo, channel, d)
+          declareExchange(name, connectionInfo, channel, d)
         }
     }
   }
 
   private def prepareConsumer[F[_]: Effect, A: DeliveryConverter](consumerConfig: ConsumerConfig,
-                                                                  channelFactoryInfo: RabbitMQConnectionInfo,
+                                                                  connectionInfo: RabbitMQConnectionInfo,
                                                                   channel: ServerChannel,
                                                                   userReadAction: DeliveryReadAction[F, A],
                                                                   consumerListener: ConsumerListener,
@@ -502,7 +502,7 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
     }
 
     val consumer = {
-      new DefaultRabbitMQConsumer(name, channel, queueName, monitor, failureAction, consumerListener, blockingScheduler)(readAction)
+      new DefaultRabbitMQConsumer(name, channel, queueName, connectionInfo, monitor, failureAction, consumerListener, blockingScheduler)(readAction)
     }
 
     val finalConsumerTag = if (consumerTag == "Default") "" else consumerTag

--- a/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConsumer.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConsumer.scala
@@ -24,6 +24,7 @@ class DefaultRabbitMQConsumer[F[_]: Effect](
     override val name: String,
     override protected val channel: ServerChannel,
     override protected val queueName: String,
+    override protected val connectionInfo: RabbitMQConnectionInfo,
     override protected val monitor: Monitor,
     failureAction: DeliveryResult,
     consumerListener: ConsumerListener,
@@ -153,4 +154,5 @@ class DefaultRabbitMQConsumer[F[_]: Effect](
 
 object DefaultRabbitMQConsumer {
   final val RepublishOriginalRoutingKeyHeaderName = "X-Original-Routing-Key"
+  final val RepublishOriginalUserId = "X-Original-User-Id"
 }

--- a/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQPullConsumer.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQPullConsumer.scala
@@ -20,6 +20,7 @@ class DefaultRabbitMQPullConsumer[F[_]: Effect, A: DeliveryConverter](
     override val name: String,
     protected override val channel: ServerChannel,
     protected override val queueName: String,
+    protected override val connectionInfo: RabbitMQConnectionInfo,
     failureAction: DeliveryResult,
     protected override val monitor: Monitor,
     protected override val blockingScheduler: Scheduler)(implicit sch: Scheduler)

--- a/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
@@ -186,7 +186,8 @@ object RabbitMQConnection extends StrictLogging {
           connection = connection,
           info = RabbitMQConnectionInfo(
             hosts = connectionConfig.hosts.toVector,
-            virtualHost = connectionConfig.virtualHost
+            virtualHost = connectionConfig.virtualHost,
+            username = if (connectionConfig.credentials.enabled) Option(connectionConfig.credentials.username) else None
           ),
           config = providedConfig,
           connectionListener = connectionListener,

--- a/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
@@ -28,7 +28,7 @@ case class Ssl(enabled: Boolean, trustStore: TrustStore)
 
 case class TrustStore(path: Path, password: String)
 
-private[rabbitmq] case class RabbitMQConnectionInfo(hosts: immutable.Seq[String], virtualHost: String)
+private[rabbitmq] case class RabbitMQConnectionInfo(hosts: immutable.Seq[String], virtualHost: String, username: Option[String])
 
 case class ConsumerConfig(queueName: String,
                           processTimeout: Duration,

--- a/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConsumerTest.scala
+++ b/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConsumerTest.scala
@@ -18,10 +18,14 @@ import org.mockito.Mockito._
 import org.scalatest.time.{Seconds, Span}
 
 import scala.collection.mutable
+import scala.collection.immutable
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Random, Success}
 
 class DefaultRabbitMQConsumerTest extends TestBase {
+
+  private val connectionInfo = RabbitMQConnectionInfo(immutable.Seq("localhost"), "/", None)
+
   test("should ACK") {
     val messageId = UUID.randomUUID().toString
 
@@ -39,6 +43,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       Monitor.noOp,
       DeliveryResult.Reject,
       DefaultListeners.DefaultConsumerListener,
@@ -77,6 +82,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       Monitor.noOp,
       DeliveryResult.Reject,
       DefaultListeners.DefaultConsumerListener,
@@ -115,6 +121,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       Monitor.noOp,
       DeliveryResult.Reject,
       DefaultListeners.DefaultConsumerListener,
@@ -152,6 +159,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       Monitor.noOp,
       DeliveryResult.Reject,
       DefaultListeners.DefaultConsumerListener,
@@ -190,6 +198,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       Monitor.noOp,
       DeliveryResult.Retry,
       DefaultListeners.DefaultConsumerListener,
@@ -225,6 +234,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       Monitor.noOp,
       DeliveryResult.Retry,
       DefaultListeners.DefaultConsumerListener,
@@ -288,6 +298,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
         "test",
         channel,
         "queueName",
+        connectionInfo,
         monitor,
         DeliveryResult.Retry,
         DefaultListeners.DefaultConsumerListener,
@@ -315,6 +326,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
         "test",
         channel,
         "queueName",
+        connectionInfo,
         monitor,
         DeliveryResult.Retry,
         DefaultListeners.DefaultConsumerListener,
@@ -381,6 +393,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
         "test",
         channel,
         "queueName",
+        connectionInfo,
         monitor,
         DeliveryResult.Retry,
         DefaultListeners.DefaultConsumerListener,
@@ -408,6 +421,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
         "test",
         channel,
         "queueName",
+        connectionInfo,
         monitor,
         DeliveryResult.Retry,
         DefaultListeners.DefaultConsumerListener,

--- a/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQPullConsumerTest.scala
+++ b/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQPullConsumerTest.scala
@@ -16,9 +16,12 @@ import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.scalatest.time.{Seconds, Span}
 
+import scala.collection.immutable
 import scala.util.Random
 
 class DefaultRabbitMQPullConsumerTest extends TestBase {
+
+  private val connectionInfo = RabbitMQConnectionInfo(immutable.Seq("localhost"), "/", None)
 
   test("should ACK") {
     val messageId = UUID.randomUUID().toString
@@ -43,6 +46,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       DeliveryResult.Reject,
       Monitor.noOp,
       Scheduler.global
@@ -85,6 +89,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       DeliveryResult.Reject,
       Monitor.noOp,
       Scheduler.global
@@ -127,6 +132,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       DeliveryResult.Ack,
       Monitor.noOp,
       Scheduler.global
@@ -168,6 +174,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       DeliveryResult.Reject,
       Monitor.noOp,
       Scheduler.global
@@ -216,6 +223,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       DeliveryResult.Retry,
       Monitor.noOp,
       Scheduler.global
@@ -260,6 +268,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
       "test",
       channel,
       "queueName",
+      connectionInfo,
       DeliveryResult.Ack,
       Monitor.noOp,
       Scheduler.global


### PR DESCRIPTION
`UserID` of published message must be same as `username` of the publishing user, [see documentation](https://www.rabbitmq.com/validated-user-id.html).

So if `UserID` is set then replace it with current username during republish.