### PR TITLE
Fix #36 - Auto declare exchange uses producer name instead of exchange name

### DIFF
--- a/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQClientFactory.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQClientFactory.scala
@@ -106,7 +106,6 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
       connectionInfo: RabbitMQConnectionInfo,
       blocker: Blocker,
       monitor: Monitor)(implicit cs: ContextShift[F]): DefaultRabbitMQProducer[F, A] = {
-    import producerConfig._
 
     val defaultProperties = MessageProperties(
       deliveryMode = DeliveryMode.fromCode(producerConfig.properties.deliveryMode),
@@ -116,11 +115,19 @@ private[rabbitmq] object DefaultRabbitMQClientFactory extends LazyLogging {
     )
 
     // auto declare exchange; if configured
-    declare.foreach {
-      declareExchange(name, connectionInfo, channel, _)
+    producerConfig.declare.foreach {
+      declareExchange(producerConfig.exchange, connectionInfo, channel, _)
     }
 
-    new DefaultRabbitMQProducer[F, A](producerConfig.name, exchange, channel, defaultProperties, reportUnroutable, blocker, monitor)
+    new DefaultRabbitMQProducer[F, A](
+      producerConfig.name,
+      producerConfig.exchange,
+      channel,
+      defaultProperties,
+      producerConfig.reportUnroutable,
+      blocker,
+      monitor
+    )
   }
 
   private[rabbitmq] def declareExchange(name: String,


### PR DESCRIPTION
Fix #36 - Auto declare exchange uses producer name instead of exchange name

For the details of this PR , please have a look at the issue ticket #36.