### PR TITLE
Streaming support

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,6 +2,7 @@ archivesBaseName = "rabbitmq-client-api_$scalaVersion"
 
 dependencies {
     compile "com.avast.bytes:bytes-core:${bytesVersion}"
+    compile "co.fs2:fs2-core_$scalaVersion:$fs2Version"
 
     compile "com.kailuowang:mainecoon-core_$scalaVersion:0.6.2"
 }

--- a/api/src/main/scala/com/avast/clients/rabbitmq/api/RabbitMQStreamingConsumer.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/api/RabbitMQStreamingConsumer.scala
@@ -1,0 +1,16 @@
+package com.avast.clients.rabbitmq.api
+
+import scala.language.higherKinds
+
+trait RabbitMQStreamingConsumer[F[_], A] {
+  def deliveryStream: fs2.Stream[F, StreamedDelivery[F, A]]
+}
+
+trait StreamedDelivery[+F[_], +A] {
+  def delivery: Delivery[A]
+
+  def handle(result: DeliveryResult): F[StreamedResult]
+}
+
+sealed trait StreamedResult
+object StreamedResult extends StreamedResult

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,12 @@ subprojects {
         scalaCompileOptions.additionalParameters = ['-target:jvm-1.8']
     }
 
+    test {
+        testLogging {
+            showStandardStreams = true
+        }
+    }
+
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
 
@@ -100,6 +106,7 @@ subprojects {
         cactusVersion = "0.16.12"
         catsVersion = "2.0.0"
         catsEffectVersion = "2.0.0"
+        fs2Version = "2.2.1"
         monixVersion = "3.0.0" // just for tests!
     }
 
@@ -124,7 +131,7 @@ subprojects {
     }
 
     tasks.withType(ScalaCompile) {
-        List plugins = configurations.scalaCompilerPlugin.files.collect{ "-Xplugin:${it.getAbsolutePath()}".toString() }
+        List plugins = configurations.scalaCompilerPlugin.files.collect { "-Xplugin:${it.getAbsolutePath()}".toString() }
         plugins.add("-Ypartial-unification")
         scalaCompileOptions.additionalParameters = plugins
     }

--- a/core/src/main/scala/com/avast/clients/rabbitmq/ConsumerWithCallbackBase.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/ConsumerWithCallbackBase.scala
@@ -1,0 +1,119 @@
+package com.avast.clients.rabbitmq
+
+import java.time.{Duration, Instant}
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.atomic.AtomicInteger
+
+import cats.effect.{Effect, Sync}
+import cats.syntax.all._
+import com.avast.bytes.Bytes
+import com.avast.clients.rabbitmq.JavaConverters._
+import com.avast.clients.rabbitmq.api.{Delivery, DeliveryResult}
+import com.avast.metrics.scalaapi._
+import com.rabbitmq.client.AMQP.BasicProperties
+import com.rabbitmq.client.{DefaultConsumer, ShutdownSignalException}
+
+import scala.collection.JavaConverters._
+import scala.language.higherKinds
+import scala.util.control.NonFatal
+
+abstract class ConsumerWithCallbackBase[F[_]: Effect](channel: ServerChannel,
+                                                      failureAction: DeliveryResult,
+                                                      consumerListener: ConsumerListener)
+    extends DefaultConsumer(channel)
+    with ConsumerBase[F] {
+
+  override protected implicit val F: Sync[F] = Effect[F]
+
+  protected val readMeter: Meter = monitor.meter("read")
+
+  protected val processingFailedMeter: Meter = resultsMonitor.meter("processingFailed")
+
+  protected val tasksMonitor: Monitor = monitor.named("tasks")
+
+  protected val processingCount: AtomicInteger = new AtomicInteger(0)
+
+  tasksMonitor.gauge("processing")(() => processingCount.get())
+
+  protected val processedTimer: TimerPair = tasksMonitor.timerPair("processed")
+
+  override def handleShutdownSignal(consumerTag: String, sig: ShutdownSignalException): Unit =
+    consumerListener.onShutdown(this, channel, name, consumerTag, sig)
+
+  protected def handleDelivery(messageId: String, deliveryTag: Long, properties: BasicProperties, routingKey: String, body: Array[Byte])(
+      readAction: DeliveryReadAction[F, Bytes]): F[Unit] =
+    F.delay {
+      try {
+        readMeter.mark()
+
+        logger.debug(s"[$name] Read delivery with ID $messageId, deliveryTag $deliveryTag")
+
+        val delivery = Delivery(Bytes.copyFrom(body), properties.asScala, Option(routingKey).getOrElse(""))
+
+        logger.trace(s"[$name] Received delivery: $delivery")
+
+        val st = Instant.now()
+
+        @inline
+        def taskDuration: Duration = Duration.between(st, Instant.now())
+
+        readAction(delivery)
+          .flatMap { handleResult(messageId, deliveryTag, properties, routingKey, body) }
+          .flatTap(_ =>
+            F.delay {
+              val duration = taskDuration
+              logger.debug(s"[$name] Delivery ID $messageId handling succeeded in $duration")
+              processedTimer.update(duration)
+          })
+          .recoverWith {
+            case NonFatal(t) =>
+              F.delay {
+                val duration = taskDuration
+                logger.debug(s"[$name] Delivery ID $messageId handling failed in $duration", t)
+                processedTimer.updateFailure(duration)
+              } >>
+                handleCallbackFailure(messageId, deliveryTag, properties, routingKey, body)(t)
+          }
+      } catch {
+        // we catch this specific exception, handling of others is up to Lyra
+        case e: RejectedExecutionException =>
+          logger.debug(s"[$name] Executor was unable to plan the handling task", e)
+          handleFailure(messageId, deliveryTag, properties, routingKey, body, e)
+
+        case NonFatal(e) => handleCallbackFailure(messageId, deliveryTag, properties, routingKey, body)(e)
+      }
+    }.flatten
+
+  private def handleCallbackFailure(messageId: String,
+                                    deliveryTag: Long,
+                                    properties: BasicProperties,
+                                    routingKey: String,
+                                    body: Array[Byte])(t: Throwable): F[Unit] = {
+    F.delay {
+      logger.error(s"[$name] Error while executing callback, it's probably a BUG", t)
+    } >>
+      handleFailure(messageId, deliveryTag, properties, routingKey, body, t)
+  }
+
+  private def handleFailure(messageId: String,
+                            deliveryTag: Long,
+                            properties: BasicProperties,
+                            routingKey: String,
+                            body: Array[Byte],
+                            t: Throwable): F[Unit] = {
+    F.delay {
+      processingCount.decrementAndGet()
+      processingFailedMeter.mark()
+      consumerListener.onError(this, name, channel, t)
+    } >>
+      executeFailureAction(messageId, deliveryTag, properties, routingKey, body)
+  }
+
+  private def executeFailureAction(messageId: String,
+                                   deliveryTag: Long,
+                                   properties: BasicProperties,
+                                   routingKey: String,
+                                   body: Array[Byte]): F[Unit] = {
+    handleResult(messageId, deliveryTag, properties, routingKey, body)(failureAction)
+  }
+}

--- a/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConsumer.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConsumer.scala
@@ -1,14 +1,9 @@
 package com.avast.clients.rabbitmq
 
-import java.time.{Duration, Instant}
-import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.atomic.AtomicInteger
-
 import cats.effect._
 import cats.implicits._
 import com.avast.bytes.Bytes
 import com.avast.clients.rabbitmq.api._
-import JavaConverters._
 import com.avast.metrics.scalaapi.Monitor
 import com.rabbitmq.client.AMQP.BasicProperties
 import com.rabbitmq.client.{Delivery => _, _}
@@ -16,7 +11,6 @@ import com.typesafe.scalalogging.StrictLogging
 
 import scala.collection.JavaConverters._
 import scala.language.higherKinds
-import scala.util.control.NonFatal
 
 class DefaultRabbitMQConsumer[F[_]: Effect](
     override val name: String,
@@ -27,29 +21,12 @@ class DefaultRabbitMQConsumer[F[_]: Effect](
     failureAction: DeliveryResult,
     consumerListener: ConsumerListener,
     override protected val blocker: Blocker)(readAction: DeliveryReadAction[F, Bytes])(implicit override protected val cs: ContextShift[F])
-    extends DefaultConsumer(channel)
+    extends ConsumerWithCallbackBase(channel, failureAction, consumerListener)
     with RabbitMQConsumer[F]
     with ConsumerBase[F]
     with StrictLogging {
 
   import DefaultRabbitMQConsumer._
-
-  override protected implicit val F: Sync[F] = Effect[F]
-
-  private val readMeter = monitor.meter("read")
-
-  private val processingFailedMeter = resultsMonitor.meter("processingFailed")
-
-  private val tasksMonitor = monitor.named("tasks")
-
-  private val processingCount = new AtomicInteger(0)
-
-  tasksMonitor.gauge("processing")(() => processingCount.get())
-
-  private val processedTimer = tasksMonitor.timerPair("processed")
-
-  override def handleShutdownSignal(consumerTag: String, sig: ShutdownSignalException): Unit =
-    consumerListener.onShutdown(this, channel, name, consumerTag, sig)
 
   override def handleDelivery(consumerTag: String, envelope: Envelope, properties: BasicProperties, body: Array[Byte]): Unit = {
     processingCount.incrementAndGet()
@@ -61,7 +38,7 @@ class DefaultRabbitMQConsumer[F[_]: Effect](
       case None => envelope.getRoutingKey
     }
 
-    val action = handleDelivery(messageId, deliveryTag, properties, routingKey, body)
+    val action = handleDelivery(messageId, deliveryTag, properties, routingKey, body)(readAction)
       .flatTap(_ =>
         F.delay {
           processingCount.decrementAndGet()
@@ -77,96 +54,10 @@ class DefaultRabbitMQConsumer[F[_]: Effect](
             F.raiseError(e)
       }
 
-    toIO(action).unsafeToFuture() // actually start the processing
+    Effect[F].toIO(action).unsafeToFuture() // actually start the processing
 
     ()
   }
-
-  private def handleDelivery(messageId: String,
-                             deliveryTag: Long,
-                             properties: BasicProperties,
-                             routingKey: String,
-                             body: Array[Byte]): F[Unit] =
-    F.delay {
-      try {
-        readMeter.mark()
-
-        logger.debug(s"[$name] Read delivery with ID $messageId, deliveryTag $deliveryTag")
-
-        val delivery = Delivery(Bytes.copyFrom(body), properties.asScala, Option(routingKey).getOrElse(""))
-
-        logger.trace(s"[$name] Received delivery: $delivery")
-
-        val st = Instant.now()
-
-        @inline
-        def taskDuration: Duration = Duration.between(st, Instant.now())
-
-        readAction(delivery)
-          .flatMap {
-            handleResult(messageId, deliveryTag, properties, routingKey, body)
-          }
-          .flatTap(_ =>
-            F.delay {
-              val duration = taskDuration
-              logger.debug(s"[$name] Delivery ID $messageId handling succeeded in $duration")
-              processedTimer.update(duration)
-          })
-          .recoverWith {
-            case NonFatal(t) =>
-              F.delay {
-                val duration = taskDuration
-                logger.debug(s"[$name] Delivery ID $messageId handling failed in $duration", t)
-                processedTimer.updateFailure(duration)
-              } >>
-                handleCallbackFailure(messageId, deliveryTag, properties, routingKey, body)(t)
-          }
-      } catch {
-        // we catch this specific exception, handling of others is up to Lyra
-        case e: RejectedExecutionException =>
-          logger.debug(s"[$name] Executor was unable to plan the handling task", e)
-          handleFailure(messageId, deliveryTag, properties, routingKey, body, e)
-
-        case NonFatal(e) => handleCallbackFailure(messageId, deliveryTag, properties, routingKey, body)(e)
-      }
-    }.flatten
-
-  private def handleCallbackFailure(messageId: String,
-                                    deliveryTag: Long,
-                                    properties: BasicProperties,
-                                    routingKey: String,
-                                    body: Array[Byte])(t: Throwable): F[Unit] = {
-    F.delay {
-      logger.error(s"[$name] Error while executing callback, it's probably a BUG", t)
-    } >>
-      handleFailure(messageId, deliveryTag, properties, routingKey, body, t)
-  }
-
-  private def handleFailure(messageId: String,
-                            deliveryTag: Long,
-                            properties: BasicProperties,
-                            routingKey: String,
-                            body: Array[Byte],
-                            t: Throwable): F[Unit] = {
-    F.delay {
-      processingCount.decrementAndGet()
-      processingFailedMeter.mark()
-      consumerListener.onError(this, name, channel, t)
-    } >>
-      executeFailureAction(messageId, deliveryTag, properties, routingKey, body)
-  }
-  private def executeFailureAction(messageId: String,
-                                   deliveryTag: Long,
-                                   properties: BasicProperties,
-                                   routingKey: String,
-                                   body: Array[Byte]): F[Unit] = {
-    handleResult(messageId, deliveryTag, properties, routingKey, body)(failureAction)
-  }
-
-  private def toIO[A](f: F[A]): IO[A] =
-    IO.async { cb =>
-      Effect[F].runAsync(f)(r => IO(cb(r))).unsafeRunSync()
-    }
 }
 
 object DefaultRabbitMQConsumer {

--- a/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQStreamingConsumer.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/DefaultRabbitMQStreamingConsumer.scala
@@ -1,0 +1,285 @@
+package com.avast.clients.rabbitmq
+
+import cats.effect.concurrent._
+import cats.effect.{Blocker, CancelToken, ConcurrentEffect, ContextShift, Effect, ExitCase, IO, Resource, Sync}
+import cats.syntax.all._
+import com.avast.bytes.Bytes
+import com.avast.clients.rabbitmq.DefaultRabbitMQConsumer.RepublishOriginalRoutingKeyHeaderName
+import com.avast.clients.rabbitmq.DefaultRabbitMQStreamingConsumer.DeliveryQueue
+import com.avast.clients.rabbitmq.api._
+import com.avast.metrics.scalaapi.Monitor
+import com.rabbitmq.client.{Delivery => _, _}
+import com.typesafe.scalalogging.StrictLogging
+import fs2.Stream
+import fs2.concurrent.Queue
+
+import scala.language.higherKinds
+import scala.util.control.NonFatal
+
+class DefaultRabbitMQStreamingConsumer[F[_]: ConcurrentEffect, A: DeliveryConverter] private (
+    name: String,
+    queueName: String,
+    initialConsumerTag: String,
+    connectionInfo: RabbitMQConnectionInfo,
+    consumerListener: ConsumerListener,
+    monitor: Monitor,
+    blocker: Blocker)(createQueue: F[DeliveryQueue[F, Bytes]], newChannel: F[ServerChannel])(implicit cs: ContextShift[F])
+    extends RabbitMQStreamingConsumer[F, A]
+    with StrictLogging {
+
+  private lazy val F: Sync[F] = Sync[F]
+
+  private lazy val streamFailureMeter = monitor.meter("streamFailures")
+
+  private lazy val recoveringMutex: Semaphore[F] = newMutexSemaphore()
+
+  private lazy val consumer = Ref.unsafe[F, Option[StreamingConsumer]](None)
+  private lazy val isClosed = Ref.unsafe[F, Boolean](false)
+  private lazy val isOk = Ref.unsafe[F, Boolean](false)
+  private lazy val tasks = Ref.unsafe[IO, Set[CancelToken[IO]]](Set.empty)
+
+  lazy val deliveryStream: fs2.Stream[F, StreamedDelivery[F, A]] = {
+    Stream
+      .eval { checkNotClosed >> recoverIfNeeded }
+      .flatMap { queue =>
+        queue.dequeue
+          .map {
+            case (del, deff) =>
+              new StreamedDelivery[F, A] {
+                override val delivery: Delivery[A] = DefaultRabbitMQClientFactory.convertDelivery(del)
+                override def handle(result: DeliveryResult): F[StreamedResult] = deff.complete(result).map(_ => StreamedResult)
+              }
+          }
+      }
+      .onFinalizeCase(handleStreamFinalize)
+  }
+
+  private lazy val recoverIfNeeded: F[DeliveryQueue[F, Bytes]] = {
+    recoveringMutex.withPermit {
+      isOk.get.flatMap {
+        case true => getCurrentQueue
+        case false => recover
+      }
+    }
+  }
+
+  private lazy val getCurrentQueue: F[DeliveryQueue[F, Bytes]] = {
+    consumer.get.map { cons =>
+      cons
+        .getOrElse(throw new IllegalStateException("Consumer has to be initialized at this stage! It's probably a BUG"))
+        .queue
+    }
+  }
+
+  private lazy val recover: F[DeliveryQueue[F, Bytes]] = {
+    createQueue.flatTap { newQueue =>
+      newChannel.flatMap { newChannel =>
+        val newConsumer = new StreamingConsumer(newChannel, newQueue)
+
+        consumer
+          .getAndSet(Some(newConsumer))
+          .flatMap {
+            case Some(oldConsumer) =>
+              blocker
+                .delay {
+                  val consumerTag = oldConsumer.getConsumerTag
+                  logger.debug(s"[$name] Cancelling consumer with consumer tag $consumerTag")
+
+                  try {
+                    oldConsumer.channel.close()
+                  } catch {
+                    case NonFatal(e) => logger.debug(s"Could not close channel", e)
+                  }
+
+                  consumerTag
+                }
+                .flatTap(_ => tryCancelRunningTasks)
+
+            case None =>
+              F.delay {
+                logger.debug("No old consumer to be cancelled!")
+                initialConsumerTag
+              }
+          }
+          .flatMap { consumerTag =>
+            blocker.delay {
+              logger.debug("Starting consuming")
+              DefaultRabbitMQClientFactory.startConsumingQueue(newChannel, queueName, consumerTag, newConsumer)
+              ()
+            }
+          } >> isOk.set(true)
+      }
+    }
+  }
+
+  private lazy val close: F[Unit] = recoveringMutex.withPermit {
+    isOk.get.flatMap { isOk =>
+      if (isOk) consumer.get.flatMap {
+        case Some(streamingConsumer) =>
+          blocker.delay {
+            streamingConsumer.stopConsuming()
+            streamingConsumer.channel.close()
+          }
+
+        case None => F.unit
+      } else F.unit
+    } >> isOk.set(false) >> isClosed.set(true)
+  }
+
+  private lazy val tryCancelRunningTasks: F[Unit] = {
+    tasks
+      .update { tasks =>
+        tasks.foreach(_.unsafeRunSync())
+        Set.empty
+      }
+      .to[F]
+  }
+
+  private lazy val stopConsuming: F[Unit] = {
+    recoveringMutex.withPermit {
+      isOk.set(false) >> consumer.get.flatMap(_.fold(F.unit)(_.stopConsuming())) // stop consumer, if there is some
+    }
+  }
+
+  private lazy val checkNotClosed: F[Unit] = {
+    isClosed.get.flatMap(cl => if (cl) F.raiseError[Unit](new IllegalStateException("This consumer is already closed")) else F.unit)
+  }
+
+  private def handleStreamFinalize(e: ExitCase[Throwable]): F[Unit] = e match {
+    case ExitCase.Completed =>
+      stopConsuming
+        .flatTap(_ => F.delay(logger.debug(s"[$name] Delivery stream was completed")))
+
+    case ExitCase.Canceled =>
+      stopConsuming
+        .flatTap(_ => F.delay(logger.debug(s"[$name] Delivery stream was cancelled")))
+
+    case ExitCase.Error(e: ShutdownSignalException) =>
+      stopConsuming
+        .flatTap { _ =>
+          F.delay {
+            streamFailureMeter.mark()
+            logger.error(s"[$name] Delivery stream was terminated because of channel shutdown. It might be a BUG int the client", e)
+          }
+        }
+
+    case ExitCase.Error(e) =>
+      stopConsuming
+        .flatTap(_ =>
+          F.delay {
+            streamFailureMeter.mark()
+            logger.debug(s"[$name] Delivery stream was terminated", e)
+        })
+  }
+
+  private def deliveryCallback(delivery: Delivery[Bytes]): F[DeliveryResult] = {
+    for {
+      deferred <- Deferred[F, DeliveryResult]
+      consumerOpt <- this.consumer.get
+      consumer = consumerOpt.getOrElse(throw new IllegalStateException("Consumer has to be initialized at this stage! It's probably a BUG"))
+      _ <- consumer.queue.enqueue1((delivery, deferred))
+      res <- deferred.get
+    } yield {
+      res
+    }
+  }
+
+  private def newMutexSemaphore(): Semaphore[F] = {
+    ConcurrentEffect[F].toIO(Semaphore[F](1)).unsafeRunSync() // this doesn't block
+  }
+
+  private class StreamingConsumer(override val channel: ServerChannel, val queue: DeliveryQueue[F, Bytes])
+      extends ConsumerWithCallbackBase(channel, DeliveryResult.Retry, consumerListener) {
+    private val receivingEnabled = Ref.unsafe[F, Boolean](true)
+
+    override def handleDelivery(consumerTag: String, envelope: Envelope, properties: AMQP.BasicProperties, body: Array[Byte]): Unit = {
+      processingCount.incrementAndGet()
+
+      val deliveryTag = envelope.getDeliveryTag
+      val messageId = properties.getMessageId
+      val routingKey = Option(properties.getHeaders).flatMap(p => Option(p.get(RepublishOriginalRoutingKeyHeaderName))) match {
+        case Some(originalRoutingKey) => originalRoutingKey.toString
+        case None => envelope.getRoutingKey
+      }
+
+      val task: F[Unit] = receivingEnabled.get.flatMap {
+        case false =>
+          F.delay {
+            logger.trace(s"Delivery $messageId (tag $deliveryTag) was ignored because consumer is not OK - it will be redelivered later")
+            processingCount.decrementAndGet()
+            ()
+          }
+
+        case true =>
+          val action = handleDelivery(messageId, deliveryTag, properties, routingKey, body)(deliveryCallback)
+            .flatTap(_ => F.delay(logger.debug(s"Delivery $messageId processed successfully (tag $deliveryTag)")))
+            .recoverWith {
+              case e =>
+                F.delay {
+                  processingFailedMeter.mark()
+                  logger.debug("Could not process delivery", e)
+                } >> F.raiseError(e)
+            }
+
+          recoveringMutex.withPermit(F.suspend {
+            lazy val ct: CancelToken[IO] = Effect[F]
+              .toIO(action)
+              .runCancelable(_ => {
+                processingCount.decrementAndGet()
+                tasks.update(_ - ct)
+              })
+              .unsafeRunSync()
+
+            tasks.update(_ + ct).to[F]
+          })
+      }
+
+      Effect[F].toIO(task).unsafeToFuture()
+
+      ()
+    }
+
+    def stopConsuming(): F[Unit] = {
+      receivingEnabled.set(false) >> blocker.delay {
+        logger.debug(s"Stopping consummation for $getConsumerTag")
+        channel.basicCancel(getConsumerTag)
+        channel.setDefaultConsumer(null)
+      }
+    }
+
+    override protected implicit val cs: ContextShift[F] = DefaultRabbitMQStreamingConsumer.this.cs
+    override protected def name: String = DefaultRabbitMQStreamingConsumer.this.name
+    override protected def queueName: String = DefaultRabbitMQStreamingConsumer.this.queueName
+    override protected def blocker: Blocker = DefaultRabbitMQStreamingConsumer.this.blocker
+    override protected def connectionInfo: RabbitMQConnectionInfo = DefaultRabbitMQStreamingConsumer.this.connectionInfo
+    override protected def monitor: Monitor = DefaultRabbitMQStreamingConsumer.this.monitor
+  }
+}
+
+object DefaultRabbitMQStreamingConsumer extends StrictLogging {
+
+  private type DeliveryQueue[F[_], A] = Queue[F, (Delivery[A], Deferred[F, DeliveryResult])]
+
+  def apply[F[_]: ConcurrentEffect, A: DeliveryConverter](
+      name: String,
+      newChannel: F[ServerChannel],
+      initialConsumerTag: String,
+      queueName: String,
+      connectionInfo: RabbitMQConnectionInfo,
+      consumerListener: ConsumerListener,
+      queueBufferSize: Int,
+      monitor: Monitor,
+      blocker: Blocker)(implicit cs: ContextShift[F]): Resource[F, DefaultRabbitMQStreamingConsumer[F, A]] = {
+    val newQueue: F[DeliveryQueue[F, Bytes]] = createQueue(queueBufferSize)
+
+    Resource.make(Sync[F].delay {
+      new DefaultRabbitMQStreamingConsumer(name, queueName, initialConsumerTag, connectionInfo, consumerListener, monitor, blocker)(
+        newQueue,
+        newChannel)
+    })(_.close)
+  }
+
+  private def createQueue[F[_]: ConcurrentEffect](queueBufferSize: Int): F[DeliveryQueue[F, Bytes]] = {
+    fs2.concurrent.Queue.bounded[F, (Delivery[Bytes], Deferred[F, DeliveryResult])](queueBufferSize)
+  }
+}

--- a/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
@@ -26,7 +26,7 @@ trait RabbitMQConnection[F[_]] {
     *
     * @param consumerConfig Configuration of the consumer.
     * @param monitor    Monitor for metrics.
-    * @param readAction Action executed for each delivered message. You should never return a failed future.
+    * @param readAction Action executed for each delivered message. You should never return a failed F.
     */
   def newConsumer[A: DeliveryConverter](consumerConfig: ConsumerConfig, monitor: Monitor)(
       readAction: DeliveryReadAction[F, A]): Resource[F, RabbitMQConsumer[F]]
@@ -45,6 +45,14 @@ trait RabbitMQConnection[F[_]] {
     */
   def newPullConsumer[A: DeliveryConverter](pullConsumerConfig: PullConsumerConfig,
                                             monitor: Monitor): Resource[F, RabbitMQPullConsumer[F, A]]
+
+  /** Creates new instance of streaming consumer, using the passed configuration.
+    *
+    * @param consumerConfig Configuration of the consumer.
+    * @param monitor Monitor for metrics.
+    */
+  def newStreamingConsumer[A: DeliveryConverter](consumerConfig: StreamingConsumerConfig,
+                                                 monitor: Monitor): Resource[F, RabbitMQStreamingConsumer[F, A]]
 
   def declareExchange(config: DeclareExchangeConfig): F[Unit]
   def declareQueue(config: DeclareQueueConfig): F[Unit]

--- a/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
@@ -32,6 +32,14 @@ final case class ConsumerConfig(name: String,
                                 declare: Option[AutoDeclareQueueConfig] = None,
                                 consumerTag: String = "Default")
 
+final case class StreamingConsumerConfig(name: String,
+                                         queueName: String,
+                                         bindings: immutable.Seq[AutoBindQueueConfig],
+                                         prefetchCount: Int = 100,
+                                         queueBufferSize: Int = 100,
+                                         declare: Option[AutoDeclareQueueConfig] = None,
+                                         consumerTag: String = "Default")
+
 final case class PullConsumerConfig(name: String,
                                     queueName: String,
                                     bindings: immutable.Seq[AutoBindQueueConfig],

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -89,6 +89,46 @@ myConfig {
         }
       ]
     }
+
+    testingStreaming {
+      name = "Testing"
+
+      queueName = "QUEUE1"
+
+      declare {
+        enabled = true
+      }
+
+      prefetchCount = 500
+
+      bindings = [
+        {
+          routingKeys = ["test"]
+
+          exchange {
+            name = "EXCHANGE1"
+
+            declare {
+              enabled = true
+
+              type = "direct"
+            }
+          }
+        }, {
+          routingKeys = ["test2"]
+
+          exchange {
+            name = "EXCHANGE2"
+
+            declare {
+              enabled = true
+
+              type = "direct"
+            }
+          }
+        }
+      ]
+    }
   }
 
   producers {

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -4,12 +4,11 @@
         <target>System.out</target>
 
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%-10mdc{traceId}] [%thread] %-35logger{35}: %msg\(%file:%line\)%n%xThrowable{full}
-            </pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %-35logger{35}: %msg\(%file:%line\)%n%xThrowable{full}</pattern>
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConsumerTest.scala
+++ b/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQConsumerTest.scala
@@ -36,6 +36,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val consumer = new DefaultRabbitMQConsumer[Task](
       "test",
@@ -75,6 +76,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val consumer = new DefaultRabbitMQConsumer[Task](
       "test",
@@ -114,6 +116,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val consumer = new DefaultRabbitMQConsumer[Task](
       "test",
@@ -153,6 +156,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
     val properties = new BasicProperties.Builder().messageId(messageId).userId(originalUserId).build()
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val consumer = new DefaultRabbitMQConsumer[Task](
       "test",
@@ -194,6 +198,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val consumer = new DefaultRabbitMQConsumer[Task](
       "test",
@@ -230,6 +235,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val consumer = new DefaultRabbitMQConsumer[Task](
       "test",
@@ -266,6 +272,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val monitor = mock[Monitor]
     when(monitor.meter(Matchers.anyString())).thenReturn(Monitor.noOp.meter(""))
@@ -337,7 +344,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
         assertResult(Seq.empty)(failuresLengths)
         val Seq(taskLength) = successLengths.result()
 
-        assert(taskLength > 2000)
+        assert(taskLength > 1990) // 2000 minus some tolerance
       }
     }
   }
@@ -354,6 +361,7 @@ class DefaultRabbitMQConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val monitor = mock[Monitor]
     when(monitor.meter(Matchers.anyString())).thenReturn(Monitor.noOp.meter(""))

--- a/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQPullConsumerTest.scala
+++ b/core/src/test/scala/com/avast/clients/rabbitmq/DefaultRabbitMQPullConsumerTest.scala
@@ -34,6 +34,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val body = Random.nextString(5).getBytes
 
@@ -77,6 +78,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val body = Random.nextString(5).getBytes
 
@@ -120,6 +122,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val body = Random.nextString(5).getBytes
 
@@ -163,6 +166,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
     val properties = new BasicProperties.Builder().messageId(messageId).userId(originalUserId).build()
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val body = Random.nextString(5).getBytes
 
@@ -208,6 +212,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val body = Random.nextString(5).getBytes
 
@@ -253,6 +258,7 @@ class DefaultRabbitMQPullConsumerTest extends TestBase {
     when(properties.getMessageId).thenReturn(messageId)
 
     val channel = mock[AutorecoveringChannel]
+    when(channel.isOpen).thenReturn(true)
 
     val body = Random.nextString(5).getBytes
 

--- a/core/src/test/scala/com/avast/clients/rabbitmq/TestHelper.scala
+++ b/core/src/test/scala/com/avast/clients/rabbitmq/TestHelper.scala
@@ -5,7 +5,6 @@ import java.nio.charset.StandardCharsets
 
 import io.circe.generic.auto._
 import io.circe.parser._
-
 import scalaj.http.Http
 
 class TestHelper(host: String, port: Int) {
@@ -17,12 +16,50 @@ class TestHelper(host: String, port: Int) {
 
     val resp = Http(s"$RootUri/queues/%2f/$encoded").auth("guest", "guest").asString.body
 
+    println("MESSAGES COUNT:")
+    println(resp)
+
     decode[QueueProperties](resp) match {
       case Right(p) => p.messages
       case r => throw new IllegalStateException(s"Wrong response $r")
     }
   }
 
-  private case class QueueProperties(messages: Int)
+  def getPublishedCount(queueName: String): Int = {
+    val encoded = URLEncoder.encode(queueName, StandardCharsets.UTF_8.toString)
+
+    val resp = Http(s"$RootUri/queues/%2f/$encoded").auth("guest", "guest").asString.body
+
+    println("PUBLISHED COUNT:")
+    println(resp)
+
+    decode[QueueProperties](resp) match {
+      case Right(p) =>
+        p.message_stats.map(_.publish).getOrElse {
+          Console.err.println(s"Could not extract published_count for $queueName!")
+          0
+        }
+      case r => throw new IllegalStateException(s"Wrong response $r")
+    }
+  }
+
+  def deleteQueue(queueName: String, ifEmpty: Boolean = false, ifUnused: Boolean = false): Unit = {
+    println(s"Deleting queue: $queueName")
+    val encoded = URLEncoder.encode(queueName, StandardCharsets.UTF_8.toString)
+
+    val resp = Http(s"$RootUri/queues/%2f/$encoded?if-empty=$ifEmpty&if-unused=$ifUnused").method("DELETE").auth("guest", "guest").asString
+
+    val content = resp.body
+
+    val message = s"Delete queue response ${resp.statusLine}: '$content'"
+    println(message)
+
+    if (!resp.isSuccess && resp.code != 404) {
+      throw new IllegalStateException(message)
+    }
+  }
+
+  private case class QueueProperties(messages: Int, message_stats: Option[MessagesStats])
+  private case class MessagesStats(publish: Int, ack: Option[Int])
 
 }

--- a/pureconfig/src/main/scala/com/avast/clients/rabbitmq/pureconfig/PureconfigImplicits.scala
+++ b/pureconfig/src/main/scala/com/avast/clients/rabbitmq/pureconfig/PureconfigImplicits.scala
@@ -65,6 +65,7 @@ class PureconfigImplicits(implicit namingConvention: NamingConvention = CamelCas
   }
   implicit val consumerConfigReader: ConfigReader[ConsumerConfig] = deriveReader
   implicit val pullConsumerConfigReader: ConfigReader[PullConsumerConfig] = deriveReader
+  implicit val streamingConsumerConfigReader: ConfigReader[StreamingConsumerConfig] = deriveReader
   implicit val producerConfigReader: ConfigReader[ProducerConfig] = deriveReader
 
   // additional declarations:

--- a/pureconfig/src/main/scala/com/avast/clients/rabbitmq/pureconfig/pureconfig.scala
+++ b/pureconfig/src/main/scala/com/avast/clients/rabbitmq/pureconfig/pureconfig.scala
@@ -29,6 +29,7 @@ package object pureconfig {
         consumerConfigReader: ConfigReader[ConsumerConfig] = implicits.CamelCase.consumerConfigReader,
         producerConfigReader: ConfigReader[ProducerConfig] = implicits.CamelCase.producerConfigReader,
         pullConsumerConfigReader: ConfigReader[PullConsumerConfig] = implicits.CamelCase.pullConsumerConfigReader,
+        streamingConsumerConfigReader: ConfigReader[StreamingConsumerConfig] = implicits.CamelCase.streamingConsumerConfigReader,
         declareExchangeConfigReader: ConfigReader[DeclareExchangeConfig] = implicits.CamelCase.declareExchangeConfigReader,
         declareQueueConfigReader: ConfigReader[DeclareQueueConfig] = implicits.CamelCase.declareQueueConfigReader,
         bindQueueConfigReader: ConfigReader[BindQueueConfig] = implicits.CamelCase.bindQueueConfigReader,


### PR DESCRIPTION
StreamingRabbitMQConsumer - providing fs2.Stream of deliveries

Some functionality extracted from `DefaultRabbitMQConsumer` to `ConsumerWithCallbackBase`, which is now used in both _normal_ and _streaming_ consumers.

Short explanation of how `DefaultStreamingRabbitMQConsumer` works:  
When the stream is requested, it's created, which means allocation of a new channel, a new queue and creation of a new internal consumer. The consumer holds the channel and the queue which is used for converting the _stream_ of messages to `fs2.Stream`. When the stream fails, proper flag is set up and the consumer is stopped. Next stream request will cause creation of new queue, new channel and new internal consumer, followed by resetting the flag. Instance of current consumer is held in `AtomicReference`. Because of massive parallelism, it's needed to synchronize on few places, either by `synchronizes` block or by using a `Semaphore`.