### PR TITLE
Configurable AddressResolver

### DIFF
--- a/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
@@ -10,6 +10,7 @@ import scala.concurrent.duration._
 final case class RabbitMQConnectionConfig(name: String,
                                           hosts: immutable.Seq[String],
                                           virtualHost: String,
+                                          addressResolverType: AddressResolverType = AddressResolverType.Default,
                                           connectionTimeout: FiniteDuration = 5.seconds,
                                           heartBeatInterval: FiniteDuration = 30.seconds,
                                           topologyRecovery: Boolean = true,
@@ -91,6 +92,14 @@ final case class BindExchangeConfig(sourceExchangeName: String,
                                     destExchangeName: String,
                                     routingKeys: immutable.Seq[String],
                                     arguments: BindArgumentsConfig = BindArgumentsConfig())
+
+sealed trait AddressResolverType
+object AddressResolverType {
+  case object Default extends AddressResolverType
+  case object List extends AddressResolverType
+  case object DnsRecord extends AddressResolverType
+  case object DnsSrvRecord extends AddressResolverType
+}
 
 sealed trait ExchangeType {
   val value: String

--- a/pureconfig/README.md
+++ b/pureconfig/README.md
@@ -70,6 +70,7 @@ rabbitConfig {
 myConfig {
   hosts = ["localhost:5672"]
   virtualHost = "/"
+  addressResolverType = "Default" // other possible values: List, DnsRecord, DnsSrvRecord
   
   name = "Cluster01Connection" // used for logging AND is also visible in client properties in RabbitMQ management console
 

--- a/pureconfig/src/main/scala/com/avast/clients/rabbitmq/pureconfig/PureconfigImplicits.scala
+++ b/pureconfig/src/main/scala/com/avast/clients/rabbitmq/pureconfig/PureconfigImplicits.scala
@@ -7,32 +7,13 @@ import _root_.pureconfig.generic.semiauto._
 import cats.data.NonEmptyList
 import com.avast.clients.rabbitmq.api.DeliveryResult
 import com.avast.clients.rabbitmq.api.DeliveryResult._
-import com.avast.clients.rabbitmq.{
-  AutoBindExchangeConfig,
-  AutoBindQueueConfig,
-  AutoDeclareExchangeConfig,
-  AutoDeclareQueueConfig,
-  BindArgumentsConfig,
-  BindExchangeConfig,
-  BindQueueConfig,
-  ConsumerConfig,
-  CredentialsConfig,
-  DeclareArgumentsConfig,
-  DeclareExchangeConfig,
-  DeclareQueueConfig,
-  ExchangeType,
-  NetworkRecoveryConfig,
-  ProducerConfig,
-  ProducerPropertiesConfig,
-  PullConsumerConfig,
-  RabbitMQConnectionConfig,
-  RecoveryDelayHandlers
-}
+import com.avast.clients.rabbitmq.{AddressResolverType, AutoBindExchangeConfig, AutoBindQueueConfig, AutoDeclareExchangeConfig, AutoDeclareQueueConfig, BindArgumentsConfig, BindExchangeConfig, BindQueueConfig, ConsumerConfig, CredentialsConfig, DeclareArgumentsConfig, DeclareExchangeConfig, DeclareQueueConfig, ExchangeType, NetworkRecoveryConfig, ProducerConfig, ProducerPropertiesConfig, PullConsumerConfig, RabbitMQConnectionConfig, RecoveryDelayHandlers}
 import com.rabbitmq.client.RecoveryDelayHandler
 import org.slf4j.event.Level
 import pureconfig.error._
 
 import scala.collection.JavaConverters._
+import scala.util.{Failure, Success}
 
 // scalastyle:off
 object implicits extends PureconfigImplicits( /* use defaults */ ) {
@@ -106,6 +87,13 @@ class PureconfigImplicits(implicit namingConvention: NamingConvention = CamelCas
   implicit val logLevelReader: ConfigReader[Level] = ConfigReader.stringConfigReader.map(Level.valueOf)
   implicit val recoveryDelayHandlerReader: ConfigReader[RecoveryDelayHandler] = RecoveryDelayHandlerReader
   implicit val exchangeTypeReader: ConfigReader[ExchangeType] = ConfigReader.fromNonEmptyStringOpt(ExchangeType.apply)
+  implicit val addressResolverTypeReader: ConfigReader[AddressResolverType] = ConfigReader.fromNonEmptyStringTry {
+    case "Default" => Success(AddressResolverType.Default)
+    case "ListAddress" => Success(AddressResolverType.List)
+    case "DnsRecordIpAddress" => Success(AddressResolverType.DnsRecord)
+    case "DnsSrvRecordAddress" => Success(AddressResolverType.DnsSrvRecord)
+    case unknownName => Failure(new IllegalArgumentException(s"Unknown addressResolverType: $unknownName"))
+  }
 
   implicit val deliveryResultReader: ConfigReader[DeliveryResult] = ConfigReader.stringConfigReader.map {
     _.toLowerCase match {

--- a/pureconfig/src/main/scala/com/avast/clients/rabbitmq/pureconfig/PureconfigImplicits.scala
+++ b/pureconfig/src/main/scala/com/avast/clients/rabbitmq/pureconfig/PureconfigImplicits.scala
@@ -7,7 +7,7 @@ import _root_.pureconfig.generic.semiauto._
 import cats.data.NonEmptyList
 import com.avast.clients.rabbitmq.api.DeliveryResult
 import com.avast.clients.rabbitmq.api.DeliveryResult._
-import com.avast.clients.rabbitmq.{AddressResolverType, AutoBindExchangeConfig, AutoBindQueueConfig, AutoDeclareExchangeConfig, AutoDeclareQueueConfig, BindArgumentsConfig, BindExchangeConfig, BindQueueConfig, ConsumerConfig, CredentialsConfig, DeclareArgumentsConfig, DeclareExchangeConfig, DeclareQueueConfig, ExchangeType, NetworkRecoveryConfig, ProducerConfig, ProducerPropertiesConfig, PullConsumerConfig, RabbitMQConnectionConfig, RecoveryDelayHandlers}
+import com.avast.clients.rabbitmq.{pureconfig => _, _}
 import com.rabbitmq.client.RecoveryDelayHandler
 import org.slf4j.event.Level
 import pureconfig.error._


### PR DESCRIPTION
I'm proposing this change because Java client handling of address resolving changes across versions. I believe it's better to have the option to specify the address resolution strategy explicitly.

The default value is `Default` that fallbacks to the Java client algorithm. If a different value is used then the `createAddressResolver` method is overridden.