### PR TITLE
Add support for non-standard exchange types

### DIFF
--- a/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
@@ -122,12 +122,15 @@ object ExchangeType {
     case Direct.value => Some(Direct)
     case Fanout.value => Some(Fanout)
     case Topic.value => Some(Topic)
+    case n if n.startsWith("x-") => Some(Custom(n))
     case _ => None
   }
 
   case object Direct extends ExchangeType { val value: String = "direct" }
   case object Fanout extends ExchangeType { val value: String = "fanout" }
   case object Topic extends ExchangeType { val value: String = "topic" }
+
+  case class Custom(value: String) extends ExchangeType
 }
 
 trait RepublishStrategyConfig {


### PR DESCRIPTION
I need to use exchange type `x-modulus-hash` in my project. In general, there are many other types provided by the RMQ plugins, so I think ExchangeType should support those.