### PR TITLE
feat: unknown fields ignored when consuming a JSON

### DIFF
--- a/extras-protobuf/src/main/scala/com/avast/clients/rabbitmq/extras/format/ProtobufAsJsonDeliveryConverter.scala
+++ b/extras-protobuf/src/main/scala/com/avast/clients/rabbitmq/extras/format/ProtobufAsJsonDeliveryConverter.scala
@@ -17,7 +17,7 @@ object ProtobufAsJsonDeliveryConverter {
   def derive[A <: GeneratedMessageV3: ProtobufAsJsonDeliveryConverter](): ProtobufAsJsonDeliveryConverter[A] =
     implicitly[ProtobufAsJsonDeliveryConverter[A]]
 
-  private val jsonParser = JsonFormat.parser()
+  private val jsonParser = JsonFormat.parser().ignoringUnknownFields()
 
   implicit def createJsonDeliveryConverter[A <: GeneratedMessageV3: ClassTag]: ProtobufAsJsonDeliveryConverter[A] =
     new ProtobufAsJsonDeliveryConverter[A] {

--- a/extras-scalapb/src/main/scala/com/avast/clients/rabbitmq/extras/format/ScalaPBAsJsonDeliveryConverter.scala
+++ b/extras-scalapb/src/main/scala/com/avast/clients/rabbitmq/extras/format/ScalaPBAsJsonDeliveryConverter.scala
@@ -18,7 +18,7 @@ object ScalaPBAsJsonDeliveryConverter {
   def derive[A <: GeneratedMessage: GeneratedMessageCompanion: ScalaPBAsJsonDeliveryConverter](): ScalaPBAsJsonDeliveryConverter[A] =
     implicitly[ScalaPBAsJsonDeliveryConverter[A]]
 
-  private val jsonParser = new Parser()
+  private val jsonParser = new Parser().ignoringUnknownFields
 
   implicit def createJsonDeliveryConverter[A <: GeneratedMessage: GeneratedMessageCompanion: ClassTag]: ScalaPBAsJsonDeliveryConverter[A] =
     new ScalaPBAsJsonDeliveryConverter[A] {


### PR DESCRIPTION
It is useful when a new field is added to the message. Then the existing consumers don't have to be updated.