### PR TITLE
DeliveryResult extends Product with Serializable

### DIFF
--- a/api/src/main/scala/com/avast/clients/rabbitmq/api/DeliveryResult.scala
+++ b/api/src/main/scala/com/avast/clients/rabbitmq/api/DeliveryResult.scala
@@ -1,6 +1,6 @@
 package com.avast.clients.rabbitmq.api
 
-sealed trait DeliveryResult
+sealed trait DeliveryResult extends Product with Serializable
 
 object DeliveryResult {
 


### PR DESCRIPTION
Helps with type inference.
Also https://nrinaudo.github.io/scala-best-practices/adts/product_with_serializable.html
