### PR TITLE
Add configuration for max inbound message size

### DIFF
--- a/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/RabbitMQConnection.scala
@@ -216,6 +216,7 @@ object RabbitMQConnection {
     }
 
     factory.setConnectionTimeout(connectionTimeout.toMillis.toInt)
+    factory.setMaxInboundMessageBodySize(connectionConfig.maxInboundMessageBodySize)
   }
 
   // scalastyle:off

--- a/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
@@ -20,7 +20,9 @@ final case class RabbitMQConnectionConfig(name: String,
                                           channelMax: Int = 2047,
                                           credentials: CredentialsConfig,
                                           republishStrategy: RepublishStrategyConfig = RepublishStrategyConfig.DefaultExchange,
-                                          maxInboundMessageBodySize: Int = Int.MaxValue)
+                                          // This is the new hard-limit on server side. see:
+                                          // https://github.com/rabbitmq/rabbitmq-common/blob/67c4397ffa9f51d87f994aa4db4a68e8e95326ab/include/rabbit.hrl#L250
+                                          maxInboundMessageBodySize: Int = 536870912)
 
 final case class NetworkRecoveryConfig(enabled: Boolean = true, handler: RecoveryDelayHandler = RecoveryDelayHandlers.Linear())
 

--- a/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
+++ b/core/src/main/scala/com/avast/clients/rabbitmq/configuration.scala
@@ -19,7 +19,8 @@ final case class RabbitMQConnectionConfig(name: String,
                                           networkRecovery: NetworkRecoveryConfig = NetworkRecoveryConfig(),
                                           channelMax: Int = 2047,
                                           credentials: CredentialsConfig,
-                                          republishStrategy: RepublishStrategyConfig = RepublishStrategyConfig.DefaultExchange)
+                                          republishStrategy: RepublishStrategyConfig = RepublishStrategyConfig.DefaultExchange,
+                                          maxInboundMessageBodySize: Int = Int.MaxValue)
 
 final case class NetworkRecoveryConfig(enabled: Boolean = true, handler: RecoveryDelayHandler = RecoveryDelayHandlers.Linear())
 


### PR DESCRIPTION
This change in the underlying RabbitMQ library has added support for MaxInboundMessageSize configuration with a default set to 64MB:
https://github.com/rabbitmq/rabbitmq-java-client/pull/1063

This however broke the behaviour of this library for us, as we might  encounter bigger messages in our usecase.
Hence this PR makes this value configurable even when using this wrapper