### PR TITLE
feat: Scala 2.12 support dropped in order to use latest pureconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala-version: [ 2.12.13, 2.13.8 ]
+        scala-version: [ 2.13.8 ]
     steps:
       - uses: actions/checkout@v4.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scala-version: [ 2.12.13, 2.13.8 ]
+        scala-version: [ 2.13.8 ]
     steps:
       - uses: actions/checkout@v4.2.2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
     ext {
         def scalaVersionEnv = System.getenv("SCALA_VERSION")
 
-        scalaVersionFull = scalaVersionEnv != null ? scalaVersionEnv : "2.12.13"
+        scalaVersionFull = scalaVersionEnv != null ? scalaVersionEnv : "2.13.8"
         scalaVersion = "${scalaVersionFull}".split("\\.").dropRight(1).join(".")
 
         bytesVersion = "2.2.0"
@@ -40,7 +40,7 @@ allprojects {
         fs2Version = "2.5.3"
         metricsVersion = "3.0.4"
         protobufVersion = "3.25.8"
-        pureconfigVersion = "0.17.8"
+        pureconfigVersion = "0.17.9"
         scalapbVersion = "0.11.18"
         scalapbJson4sVersion = "0.11.1"
         typesafeConfigVersion = "1.4.3"


### PR DESCRIPTION
The pureconfig introduced a breaking binary change, and they also dropped support for Scala 2.12. In order to keep the dependencies up to date, we follow these changes.

https://github.com/pureconfig/pureconfig/issues/1818